### PR TITLE
Extra configuration

### DIFF
--- a/charts/kcp/templates/etcd.yaml
+++ b/charts/kcp/templates/etcd.yaml
@@ -9,8 +9,7 @@ spec:
   commonName: etcd-client-bootstrap
   secretName: etcd-client-bootstrap-secret
   privateKey:
-    algorithm: RSA
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
     name: kcp-pki-bootstrap
     kind: Issuer
@@ -25,8 +24,7 @@ spec:
   commonName: etcd-peer-bootstrap
   secretName: etcd-peer-bootstrap-secret
   privateKey:
-    algorithm: RSA
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
     name: kcp-pki-bootstrap
     kind: Issuer
@@ -60,9 +58,7 @@ spec:
     organizations:
       - redhat
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - server auth
     - client auth
@@ -91,9 +87,7 @@ spec:
     organizations:
       - redhat
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - server auth
     - client auth

--- a/charts/kcp/templates/etcd.yaml
+++ b/charts/kcp/templates/etcd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.etcd.enabled -}}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -200,3 +201,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.etcd.volumeSize }}
+{{- end }}

--- a/charts/kcp/templates/etcd.yaml
+++ b/charts/kcp/templates/etcd.yaml
@@ -54,9 +54,10 @@ spec:
   secretName: etcd-cert
   duration: 8760h0m0s # 365d
   renewBefore: 360h0m0s # 15d
+  {{ with .Values.certificates.subject }}
   subject:
-    organizations:
-      - redhat
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
@@ -83,9 +84,10 @@ spec:
   secretName: etcd-peer-cert
   duration: 8760h0m0s # 365d
   renewBefore: 360h0m0s # 15d
+  {{ with .Values.certificates.subject }}
   subject:
-    organizations:
-      - redhat
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -69,6 +69,8 @@ spec:
   - backendRefs:
     - name: kcp-front-proxy
       port: 8443
+  hostnames:
+  - {{ .Values.externalHostname }}
 {{- end }}
 ---
 apiVersion: cert-manager.io/v1

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -1,3 +1,4 @@
+{{ - if .Values.kcpFrontProxy.openShiftRoute.enabled -}}
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -14,6 +15,33 @@ spec:
     name: kcp-front-proxy
     weight: 100
   wildcardPolicy: None
+{{- end }}
+{{ - if .Values.kcpFrontProxy.ingress.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kcp-front-proxy
+  annotations:
+    {{- .Values.kcpFrontProxy.ingress.annotations | nindent 4 }}
+spec:
+  tls:
+  - hosts:
+      - {{ .Values.externalHostname }}
+    {{- with .Values.kcpFrontProxy.ingress.secret }}secretName: {{ . }}{{- end }}
+  rules:
+  - host: {{ .Values.externalHostname }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kcp-front-proxy
+            port:
+              number: 8443
+  host: {{ .Values.externalHostname }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -47,14 +47,7 @@ kind: Issuer
 metadata:
   name: kcp-front-proxy-issuer
 spec:
-  acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    privateKeySecretRef:
-      name: kcp-front-proxy-issuer-account-key
-    solvers:
-    - http01:
-        ingress:
-          serviceType: ClusterIP
+  {{- toYaml .Values.kcpFrontProxy.certificate.issuerSpec | nindent 2 }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kcpFrontProxy.openShiftRoute.enabled -}}
+{{- if .Values.kcpFrontProxy.openshiftRoute.enabled -}}
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -68,9 +68,7 @@ spec:
     organizations:
       - redhat
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - server auth
   dnsNames:
@@ -87,8 +85,7 @@ spec:
   commonName: kcp-client-ca
   secretName: kcp-client-ca
   privateKey:
-    algorithm: RSA
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
     name: kcp-pki-bootstrap
     kind: Issuer
@@ -114,9 +111,7 @@ spec:
     organizations:
       - redhat
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - client auth
   dnsNames:
@@ -137,9 +132,7 @@ spec:
     organizations:
       - "system:masters"
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - client auth
   issuerRef:
@@ -157,9 +150,7 @@ spec:
     organizations:
       - redhat
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - client auth
   dnsNames:

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kcpFrontProxy.openshiftRoute.enabled -}}
+{{- if .Values.kcpFrontProxy.openshiftRoute.enabled }}
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -16,7 +16,7 @@ spec:
     weight: 100
   wildcardPolicy: None
 {{- end }}
-{{- if .Values.kcpFrontProxy.ingress.enabled -}}
+{{- if .Values.kcpFrontProxy.ingress.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -40,6 +40,35 @@ spec:
             name: kcp-front-proxy
             port:
               number: 8443
+{{- end }}
+{{- if .Values.kcpFrontProxy.gateway.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: kcp-front-proxy
+spec:
+  gatewayClassName: {{ required "gateway.classname is required" .Values.kcpFrontProxy.gateway.className }}
+  listeners:
+  - name: tls
+    protocol: TLS
+    port: 8443
+    tls:
+      mode: Passthrough
+    hostname: {{ .Values.externalHostname }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: kcp-front-proxy
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: kcp-front-proxy
+  rules:
+  - backendRefs:
+    - name: kcp-front-proxy
+      port: 8443
 {{- end }}
 ---
 apiVersion: cert-manager.io/v1

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -40,7 +40,6 @@ spec:
             name: kcp-front-proxy
             port:
               number: 8443
-  host: {{ .Values.externalHostname }}
 {{- end }}
 ---
 apiVersion: cert-manager.io/v1

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -23,7 +23,7 @@ kind: Ingress
 metadata:
   name: kcp-front-proxy
   annotations:
-    {{- .Values.kcpFrontProxy.ingress.annotations | nindent 4 }}
+    {{- toYaml .Values.kcpFrontProxy.ingress.annotations | nindent 4 }}
 spec:
   tls:
   - hosts:

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -88,9 +88,10 @@ spec:
   secretName: kcp-front-proxy-cert
   duration: 8760h0m0s # 365d
   renewBefore: 360h0m0s # 15d
+  {{ with .Values.certificates.subject }}
   subject:
-    organizations:
-      - redhat
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
@@ -131,9 +132,10 @@ spec:
   secretName: kcp-front-proxy-kcp-client-cert
   duration: 8760h0m0s # 365d
   renewBefore: 360h0m0s # 15d
+  {{ with .Values.certificates.subject }}
   subject:
-    organizations:
-      - redhat
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
@@ -170,9 +172,10 @@ spec:
   secretName: kcp-front-proxy-virtual-workspaces-client-cert
   duration: 8760h0m0s # 365d
   renewBefore: 360h0m0s # 15d
+  {{ with .Values.certificates.subject }}
   subject:
-    organizations:
-      - redhat
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -1,4 +1,4 @@
-{{ - if .Values.kcpFrontProxy.openShiftRoute.enabled -}}
+{{- if .Values.kcpFrontProxy.openShiftRoute.enabled -}}
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -16,7 +16,7 @@ spec:
     weight: 100
   wildcardPolicy: None
 {{- end }}
-{{ - if .Values.kcpFrontProxy.ingress.enabled -}}
+{{- if .Values.kcpFrontProxy.ingress.enabled -}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -28,7 +28,7 @@ spec:
   tls:
   - hosts:
       - {{ .Values.externalHostname }}
-    {{- with .Values.kcpFrontProxy.ingress.secret }}secretName: {{ . }}{{- end }}
+    {{- with .Values.kcpFrontProxy.ingress.secret -}}secretName: {{ . }}{{- end }}
   rules:
   - host: {{ .Values.externalHostname }}
     http:

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -126,9 +126,9 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
-  storageClassName: gp2
-  volumeMode: Filesystem
+      storage: {{ .Values.kcp.storage.size }}
+  {{- with .Values.kcp.storage.className -}}storageClassName: {{ . }}{{- end }}
+  {{- with .Values.kcp.storage.volumeMode -}}volumeMode: {{ . }}{{- end }}
 {{- if .Values.audit.enabled }}
 ---
 apiVersion: v1

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -76,9 +76,10 @@ spec:
   secretName: kcp-cert
   duration: 8760h0m0s # 365d
   renewBefore: 360h0m0s # 15d
+  {{ with .Values.certificates.subject }}
   subject:
-    organizations:
-      - redhat
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
@@ -97,9 +98,10 @@ spec:
   secretName: kcp-virtual-workspaces-cert
   duration: 8760h0m0s # 365d
   renewBefore: 360h0m0s # 15d
+  {{ with .Values.certificates.subject }}
   subject:
-    organizations:
-      - redhat
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
@@ -120,7 +122,7 @@ spec:
   renewBefore: 360h0m0s # 15d
   commonName: {{ .Values.kcp.etcd.clientCertificate.commonName }}
   privateKey:
-    algorithm: Ed25519
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - client auth
   issuerRef:

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -387,4 +387,4 @@ metadata:
   name: audit-policy
 data:
   {{ .Values.audit.policy.fileName }}: |
-{{ .Values.audit.policy.config | indent 4 }}
+    {{- .Values.audit.policy.config | nindent 4 }}

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -191,7 +191,7 @@ spec:
         - /kcp
         args:
         - start
-        - --etcd-servers=https://etcd:2379
+        - --etcd-servers={{ .Values.kcp.etcdServerAddress }}
         - --etcd-keyfile=/etc/etcd/tls/server/tls.key
         - --etcd-certfile=/etc/etcd/tls/server/tls.crt
         - --etcd-cafile=/etc/etcd/tls/server/ca.crt

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -213,8 +213,8 @@ spec:
         - --oidc-client-id={{ .Values.oidc.clientId }}
         - --oidc-groups-claim={{ .Values.oidc.groupClaim }}
         - --oidc-username-claim={{ .Values.oidc.usernameClaim }}
-        - "--oidc-username-prefix=rh-sso:"
-        - "--oidc-groups-prefix=rh-sso:"
+        - "--oidc-username-prefix={{ .Values.oidc.usernamePrefix }}"
+        - "--oidc-groups-prefix={{ .Values.oidc.groupsPrefix }}:"
         {{- end }}
         - --v={{ .Values.kcp.v }}
         {{- if .Values.audit.enabled }}

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -8,8 +8,7 @@ spec:
   commonName: kcp-ca
   secretName: kcp-ca
   privateKey:
-    algorithm: RSA
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
     name: kcp-pki-bootstrap
     kind: Issuer
@@ -24,8 +23,7 @@ spec:
   commonName: kcp-requestheader-client-ca
   secretName: kcp-requestheader-client-ca
   privateKey:
-    algorithm: RSA
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
     name: kcp-pki-bootstrap
     kind: Issuer
@@ -40,8 +38,7 @@ spec:
   commonName: kcp-server-client-ca
   secretName: kcp-server-client-ca
   privateKey:
-    algorithm: RSA
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
     name: kcp-pki-bootstrap
     kind: Issuer
@@ -83,9 +80,7 @@ spec:
     organizations:
       - redhat
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - server auth
   dnsNames:
@@ -106,9 +101,7 @@ spec:
     organizations:
       - redhat
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - server auth
   dnsNames:
@@ -127,9 +120,7 @@ spec:
   renewBefore: 360h0m0s # 15d
   commonName: {{ .Values.kcp.etcd.clientCertificate.commonName }}
   privateKey:
-    algorithm: RSA
-    encoding: PKCS1
-    size: 2048
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - client auth
   issuerRef:

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -117,6 +117,24 @@ spec:
   issuerRef:
     name: kcp-server-issuer
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-etcd-client
+spec:
+  secretName: kcp-etcd-client
+  duration: 8760h0m0s # 365d
+  renewBefore: 360h0m0s # 15d
+  commonName: {{ .Values.kcp.etcd.clientCertificate.commonName }}
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - client auth
+  issuerRef:
+    name: {{ .Values.kcp.etcd.clientCertificate.issuer }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -191,7 +209,7 @@ spec:
         - /kcp
         args:
         - start
-        - --etcd-servers={{ .Values.kcp.etcdServerAddress }}
+        - --etcd-servers={{ .Values.kcp.etcd.serverAddress }}
         - --etcd-keyfile=/etc/etcd/tls/server/tls.key
         - --etcd-certfile=/etc/etcd/tls/server/tls.crt
         - --etcd-cafile=/etc/etcd/tls/server/ca.crt
@@ -347,7 +365,7 @@ spec:
       volumes:
       - name: etcd-certs
         secret:
-          secretName: etcd-cert
+          secretName: kcp-etcd-client
       - name: kcp-certs
         secret:
           secretName: kcp-cert

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -120,7 +120,7 @@ spec:
   renewBefore: 360h0m0s # 15d
   commonName: {{ .Values.kcp.etcd.clientCertificate.commonName }}
   privateKey:
-    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+    algorithm: Ed25519
   usages:
     - client auth
   issuerRef:

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -236,7 +236,7 @@ spec:
         {{- end }}
         env:
         - name: EXTERNAL_HOSTNAME
-          value: {{ .Values.externalHostname }}
+          value: {{ required "A valid external hostname is required" .Values.externalHostname }}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -126,9 +126,9 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.kcp.storage.size }}
-  {{- with .Values.kcp.storage.className -}}storageClassName: {{ . }}{{- end }}
-  {{- with .Values.kcp.storage.volumeMode -}}volumeMode: {{ . }}{{- end }}
+      storage: {{ .Values.kcp.volumeSize }}
+  {{- with .Values.kcp.volumeClassName -}}storageClassName: {{ . }}{{- end }}
+  {{- with .Values.kcp.volumeMode -}}volumeMode: {{ . }}{{- end }}
 {{- if .Values.audit.enabled }}
 ---
 apiVersion: v1
@@ -141,8 +141,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.audit.volumeSize }}
-  storageClassName: gp2
-  volumeMode: Filesystem
+  {{- with .Values.audit.volumeClassName -}}storageClassName: {{ . }}{{- end }}
+  {{- with .Values.audit.volumeMode -}}volumeMode: {{ . }}{{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -15,6 +15,12 @@ kcp:
   etcdServerAddress: https://etcd:2379
 kcpFrontProxy:
   v: "4"
+  openshiftRoute:
+    enabled: false
+  ingress:
+    enabled: true
+    annotations: {}
+    secret: ""
 virtualWorkspaces:
   cpuLimit: 200m
   memoryLimit: 1Gi

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -1,4 +1,4 @@
-externalHostname: a
+externalHostname: ""
 etcd:
   enabled: true
   image: quay.io/coreos/etcd
@@ -28,6 +28,8 @@ kcpFrontProxy:
     enabled: true
     annotations: {}
     secret: ""
+  certificate:
+    issuerSpec: {}
 virtualWorkspaces:
   cpuLimit: 200m
   memoryLimit: 1Gi

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -13,10 +13,9 @@ kcp:
   cpuLimit: "1"
   memoryLimit: 3Gi
   etcdServerAddress: https://etcd:2379
-  storage:
-    size: 1Gb
-    className: ""
-    volumeMode: ""
+  volumeSize: 1Gi
+  volumeClassName: ""
+  volumeMode: ""
 kcpFrontProxy:
   v: "4"
   openshiftRoute:
@@ -33,6 +32,8 @@ virtualWorkspaces:
 audit:
   enabled: true
   volumeSize: 1Gi
+  volumeClassName: ""
+  volumeMode: ""
   policy:
     dir: /etc/kcp/audit
     fileName: audit-policy.yml

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -52,6 +52,10 @@ audit:
     maxSize: "250"
     maxBackup: "1"
     dir: /var/audit
+certificates:
+  privateKeys:
+    algorithm: RSA
+    size: 2048
 oidc: {}
 githubUserEditAccess:
 - test

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -28,6 +28,9 @@ kcpFrontProxy:
     enabled: true
     annotations: {}
     secret: ""
+  gateway:
+    enabled: false
+    className: ""
   certificate:
     issuerSpec: {}
 virtualWorkspaces:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -1,5 +1,6 @@
 externalHostname: a
 etcd:
+  enabled: true
   image: quay.io/coreos/etcd
   tag: v3.5.4
   cpuLimit: "1"
@@ -11,6 +12,7 @@ kcp:
   v: "4"
   cpuLimit: "1"
   memoryLimit: 3Gi
+  etcdServerAddress: https://etcd:2379
 kcpFrontProxy:
   v: "4"
 virtualWorkspaces:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -25,7 +25,7 @@ kcpFrontProxy:
   openshiftRoute:
     enabled: false
   ingress:
-    enabled: true
+    enabled: false
     annotations: {}
     secret: ""
   gateway:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -61,6 +61,7 @@ certificates:
   privateKeys:
     algorithm: RSA
     size: 2048
+  subject: {}
 oidc: {}
 githubUserEditAccess:
 - test

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -12,7 +12,11 @@ kcp:
   v: "4"
   cpuLimit: "1"
   memoryLimit: 3Gi
-  etcdServerAddress: https://etcd:2379
+  etcd:
+    serverAddress: https://etcd:2379
+    clientCertificate:
+      issuer: etcd-client-issuer
+      commonName: root
   volumeSize: 1Gi
   volumeClassName: ""
   volumeMode: ""

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -13,6 +13,10 @@ kcp:
   cpuLimit: "1"
   memoryLimit: 3Gi
   etcdServerAddress: https://etcd:2379
+  storage:
+    size: 1Gb
+    className: ""
+    volumeMode: ""
 kcpFrontProxy:
   v: "4"
   openshiftRoute:


### PR DESCRIPTION
A number of changes to use kcp helm chart with an external etcd (to make maintenance easier when this is eventually ready for production), as well as removing configuration specific to the red hat environment. This PR also adds configuration to work with vanilla kubernetes via changes such as adding Ingress and Gateway configuration in addition to OpenShift Routes.