### PR TITLE
Add proper CA certificate

### DIFF
--- a/charts/kcp/templates/etcd.yaml
+++ b/charts/kcp/templates/etcd.yaml
@@ -11,7 +11,7 @@ spec:
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: kcp-pki-bootstrap
+    name: kcp-pki-ca
     kind: Issuer
     group: cert-manager.io
 ---
@@ -26,7 +26,7 @@ spec:
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: kcp-pki-bootstrap
+    name: kcp-pki-ca
     kind: Issuer
     group: cert-manager.io
 ---

--- a/charts/kcp/templates/issuer.yaml
+++ b/charts/kcp/templates/issuer.yaml
@@ -4,3 +4,28 @@ metadata:
   name: kcp-pki-bootstrap
 spec:
   selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-pki-ca
+spec:
+  isCA: true
+  commonName: kcp-pki-ca
+  secretName: kcp-pki-ca
+  duration: 8760h0m0s # 365d
+  renewBefore: 360h0m0s # 15d
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  issuerRef:
+    name: kcp-pki-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kcp-pki-ca
+spec:
+  ca:
+    secretName: kcp-pki-ca

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -112,7 +112,7 @@ spec:
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: kcp-pki-bootstrap
+    name: kcp-pki-ca
     kind: Issuer
     group: cert-manager.io
 ---

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -10,7 +10,7 @@ spec:
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: kcp-pki-bootstrap
+    name: kcp-pki-ca
     kind: Issuer
     group: cert-manager.io
 ---
@@ -25,7 +25,7 @@ spec:
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: kcp-pki-bootstrap
+    name: kcp-pki-ca
     kind: Issuer
     group: cert-manager.io
 ---
@@ -40,7 +40,7 @@ spec:
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: kcp-pki-bootstrap
+    name: kcp-pki-ca
     kind: Issuer
     group: cert-manager.io
 ---


### PR DESCRIPTION
Current cert-manager configuration had each intermediate CA actually act
as an independent root CA.  This change installs an actual root CA and
has all intermediate certs be signed by it (instead of themselves).