### PR TITLE
Add --shard-virtual-workspace-url flag

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 type: application
-version: 0.2.1
-appVersion: "0.6"
+version: 0.2.2
+appVersion: "0.7"

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -215,6 +215,7 @@ spec:
         - --shard-base-url=https://kcp:6443
         - --shard-external-url=https://$(EXTERNAL_HOSTNAME):443
         - --external-hostname=$(EXTERNAL_HOSTNAME):443
+        - --shard-virtual-workspace-url=https://$(EXTERNAL_HOSTNAME):443
         - --root-ca-file=/etc/kcp/tls/ca/root-ca.pem
         {{- if .Values.oidc }}
         - --oidc-issuer-url={{ .Values.oidc.issuerUrl }}


### PR DESCRIPTION
This flag needs to be added, otherwise now the VW url defaults to the
"base URL", which is *not* the external URL.