### PR TITLE
Make profiling containers a chart parameter

### DIFF
--- a/charts/kcp/templates/etcd.yaml
+++ b/charts/kcp/templates/etcd.yaml
@@ -180,6 +180,9 @@ spec:
                 --cert-file=/etc/etcd/tls/server/tls.crt \
                 --key-file=/etc/etcd/tls/server/tls.key \
                 --trusted-ca-file=/etc/etcd/tls/server/ca.crt \
+                {{- if .Values.etcd.profiling.enabled }}
+                --enable-pprof=true \
+                {{- end }}
                 --snapshot-count=5000
       volumes:
       - name: peer-certs

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -248,6 +248,9 @@ spec:
         - --client-ca-file=/etc/kcp-front-proxy/client/tls/ca.crt
         - --mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml
         - --v={{ .Values.kcpFrontProxy.v }}
+        {{- if .Values.kcpFrontProxy.profiling.enabled }}
+        - --profiler-address=localhost:{{- .Values.kcpFrontProxy.profiling.port -}}
+        {{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -234,6 +234,9 @@ spec:
         - --audit-policy-file={{ .Values.audit.policy.dir }}/{{ .Values.audit.policy.fileName }}
         - --audit-log-compress
         {{- end }}
+        {{- if .Values.kcp.profiling.enabled }}
+        - --profiler-address=localhost:{{- .Values.kcp.profiling.port -}}
+        {{- end }}
         {{- range .Values.kcp.extraFlags }}
         - {{ . }}
         {{- end }}
@@ -314,6 +317,9 @@ spec:
           --requestheader-group-headers=X-Remote-Group
           --secure-port=6444
           --v={{ .Values.kcp.v }}
+          {{- if .Values.virtualWorkspaces.profiling.enabled }}
+          --profiler-address=localhost:{{- .Values.virtualWorkspaces.profiling.port -}}
+          {{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -6,6 +6,8 @@ etcd:
   cpuLimit: "1"
   memoryLimit: 2Gi
   volumeSize: 8Gi
+  profiling:
+    enabled: true
 kcp:
   image: ghcr.io/kcp-dev/kcp
   tag: latest
@@ -20,6 +22,9 @@ kcp:
   volumeSize: 1Gi
   volumeClassName: ""
   extraFlags: []  # Format is raw flag, e.g. --virtual-server-url=https://abc.xyz:443
+  profiling:
+    enabled: true
+    port: 6060
 kcpFrontProxy:
   v: "4"
   openshiftRoute:
@@ -33,11 +38,17 @@ kcpFrontProxy:
     className: ""
   certificate:
     issuerSpec: {}
+  profiling:
+    enabled: true
+    port: 6060
 virtualWorkspaces:
   cpuLimit: 200m
   memoryLimit: 1Gi
   cpuRequest: 100m
   memoryRequest: 256Mi
+  profiling:
+    enabled: true
+    port: 6061
 audit:
   enabled: true
   volumeSize: 1Gi

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -7,7 +7,7 @@ etcd:
   memoryLimit: 2Gi
   volumeSize: 8Gi
   profiling:
-    enabled: true
+    enabled: false
 kcp:
   image: ghcr.io/kcp-dev/kcp
   tag: latest
@@ -23,7 +23,7 @@ kcp:
   volumeClassName: ""
   extraFlags: []  # Format is raw flag, e.g. --virtual-server-url=https://abc.xyz:443
   profiling:
-    enabled: true
+    enabled: false
     port: 6060
 kcpFrontProxy:
   v: "4"
@@ -39,7 +39,7 @@ kcpFrontProxy:
   certificate:
     issuerSpec: {}
   profiling:
-    enabled: true
+    enabled: false
     port: 6060
 virtualWorkspaces:
   cpuLimit: 200m
@@ -47,7 +47,7 @@ virtualWorkspaces:
   cpuRequest: 100m
   memoryRequest: 256Mi
   profiling:
-    enabled: true
+    enabled: false
     port: 6061
 audit:
   enabled: true


### PR DESCRIPTION
Each of the following containers will have the parameter:

* kcp
* virtual-workspaces
* kcp-front-proxy
* etcd

Note that etcd does not have a configurable port

Fixes #15