### PR TITLE
Use Openshift CI as image registry

### DIFF
--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -235,11 +235,9 @@ spec:
     spec:
       containers:
       - name: kcp-front-proxy
-        image: {{ .Values.kcp.image }}:{{ .Values.kcp.tag }}
+        image: {{ .Values.kcpFrontProxy.image }}:{{ .Values.kcpFrontProxy.tag }}
         ports:
         - containerPort: 8443
-        command:
-        - /kcp-front-proxy
         args:
         - --secure-port=8443
         - --root-kubeconfig=/etc/kcp-front-proxy/kubeconfig/root-shard.kubeconfig

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -196,8 +196,6 @@ spec:
         image: {{ .Values.kcp.image }}:{{ .Values.kcp.tag }}
         ports:
         - containerPort: 6443
-        command:
-        - /kcp
         args:
         - start
         - --etcd-servers={{ .Values.kcp.etcd.serverAddress }}
@@ -293,7 +291,7 @@ spec:
         - name: root-ca-file
           mountPath: /etc/kcp/tls/ca
       - name: virtual-workspaces
-        image: {{ .Values.kcp.image }}:{{ .Values.kcp.tag }}
+        image: {{ .Values.virtualWorkspaces.image }}:{{ .Values.virtualWorkspaces.tag }}
         ports:
         - containerPort: 6444
         command:
@@ -301,7 +299,7 @@ spec:
         - -c
         - >
           cat /etc/kcp/config/admin.kubeconfig | sed -e 's;://\([^/]*\);://localhost:6443;' -e 's;current-context: root;current-context: system:admin;' > /etc/kcp/config/localhost.kubeconfig &&
-          exec /virtual-workspaces
+          exec /usr/bin/virtual-workspaces
           workspaces
           --kubeconfig=/etc/kcp/config/localhost.kubeconfig
           --authentication-kubeconfig=/etc/kcp/config/localhost.kubeconfig

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -7,7 +7,7 @@ etcd:
   memoryLimit: 2Gi
   volumeSize: 8Gi
 kcp:
-  image: ghcr.io/kcp-dev/kcp
+  image: registry.ci.openshift.org/kcp/kcp
   tag: latest
   v: "4"
   cpuLimit: "1"
@@ -23,6 +23,8 @@ kcp:
   volumeClassName: ""
   extraFlags: []  # Format is raw flag, e.g. --virtual-server-url=https://abc.xyz:443
 kcpFrontProxy:
+  image: registry.ci.openshift.org/kcp/kcp-front-proxy
+  tag: latest
   v: "4"
   openshiftRoute:
     enabled: false
@@ -36,6 +38,8 @@ kcpFrontProxy:
   certificate:
     issuerSpec: {}
 virtualWorkspaces:
+  image: registry.ci.openshift.org/kcp/virtual-workspaces
+  tag: latest
   cpuLimit: 200m
   memoryLimit: 1Gi
   cpuRequest: 100m


### PR DESCRIPTION
The images in Openshfit CI only include one binary per image, so we also
need to allow setting different image specs for each container.

The location of each binary is changing as well, though hopefully the
entrypoint can be used going forward (after the virtual-workspace
container removes its custom inline script).