### PR TITLE
Update templates

### DIFF
--- a/charts/kcp/templates/etcd.yaml
+++ b/charts/kcp/templates/etcd.yaml
@@ -62,6 +62,7 @@ spec:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   usages:
     - server auth
+    - client auth  # required because etcd uses this cert for calls to itself
   dnsNames:
     - etcd
     - etcd-0
@@ -108,6 +109,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: etcd
+  labels:
+    app: etcd
 spec:
   clusterIP: None
   ports:
@@ -153,11 +156,19 @@ spec:
               mountPath: /etc/etcd/tls/server
           resources:
             limits:
+              {{- if .Values.etcd.cpuLimit }}
               cpu: '{{ .Values.etcd.cpuLimit }}'
+              {{- end }}
+              {{- if .Values.etcd.memoryLimit }}
               memory: '{{ .Values.etcd.memoryLimit }}'
+              {{- end }}
             requests:
-              cpu: 500m
-              memory: '{{ .Values.etcd.memoryLimit }}'
+              {{- if .Values.etcd.cpuRequest }}
+              cpu: '{{ .Values.etcd.cpuRequest }}'
+              {{- end }}
+              {{- if .Values.etcd.memoryRequest }}
+              memory: '{{ .Values.etcd.memoryRequest }}'
+              {{- end }}
           command:
             - /bin/sh
             - -c
@@ -171,6 +182,8 @@ spec:
                 --initial-cluster-token etcd-cluster-1 \
                 --initial-cluster ${PEERS} \
                 --initial-cluster-state new \
+                --auto-compaction-mode=periodic \
+                --auto-compaction-retention=5m \
                 --data-dir /var/run/etcd/default.etcd \
                 --peer-client-cert-auth=true \
                 --peer-cert-file=/etc/etcd/tls/peer/tls.crt \

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -204,11 +204,6 @@ metadata:
   name: kcp-front-proxy-config
 data:
   path-mapping.yaml: |
-    - path: /services/
-      backend: https://kcp:6444
-      backend_server_ca: /etc/virtual-workspaces/tls/ca.crt
-      proxy_client_cert: /etc/kcp-front-proxy/requestheader-client/tls/virtual-workspaces/tls.crt
-      proxy_client_key: /etc/kcp-front-proxy/requestheader-client/tls/virtual-workspaces/tls.key
     - path: /
       backend: https://kcp:6443
       backend_server_ca: /etc/kcp/tls/ca.crt
@@ -238,16 +233,29 @@ spec:
         image: {{ .Values.kcpFrontProxy.image }}:{{ .Values.kcpFrontProxy.tag }}
         ports:
         - containerPort: 8443
+        command: ["/kcp-front-proxy"]
         args:
         - --secure-port=8443
         - --root-kubeconfig=/etc/kcp-front-proxy/kubeconfig/root-shard.kubeconfig
+        {{- if .Values.kcpFrontProxy.shardsKubeConfigFlag }}
+        - --shards-kubeconfig=/etc/kcp-front-proxy/kubeconfig/root-shard.kubeconfig
+        {{- end }}
         - --tls-private-key-file=/etc/kcp-front-proxy/tls/tls.key
         - --tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt
         - --client-ca-file=/etc/kcp-front-proxy/client/tls/ca.crt
         - --mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml
         - --v={{ .Values.kcpFrontProxy.v }}
+        - --logging-format=json
         {{- if .Values.kcpFrontProxy.profiling.enabled }}
         - --profiler-address=localhost:{{- .Values.kcpFrontProxy.profiling.port -}}
+        {{- end }}
+        {{- if .Values.oidc }}
+        - --oidc-issuer-url={{ .Values.oidc.issuerUrl }}
+        - --oidc-client-id={{ .Values.oidc.clientId }}
+        - --oidc-groups-claim={{ .Values.oidc.groupClaim }}
+        - --oidc-username-claim={{ .Values.oidc.usernameClaim }}
+        - --oidc-username-prefix={{ .Values.oidc.usernamePrefix }}
+        - --oidc-groups-prefix={{ .Values.oidc.groupsPrefix }}
         {{- end }}
         livenessProbe:
           failureThreshold: 3
@@ -267,8 +275,7 @@ spec:
             scheme: HTTPS
         resources:
           limits:
-            cpu: 200m
-            memory: 256Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 128Mi

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -128,6 +128,25 @@ spec:
   issuerRef:
     name: {{ .Values.kcp.etcd.clientCertificate.issuer }}
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: logical-cluster-admin-client-cert-for-kubeconfig
+spec:
+  secretName: logical-cluster-admin-client-cert-for-kubeconfig
+  duration: 8760h0m0s # 365d
+  renewBefore: 360h0m0s # 15d
+  commonName: logical-cluster-admin
+  subject:
+    organizations:
+      - "system:kcp:logical-cluster-admin"
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  issuerRef:
+    name: kcp-server-client-issuer
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -196,8 +215,12 @@ spec:
         image: {{ .Values.kcp.image }}:{{ .Values.kcp.tag }}
         ports:
         - containerPort: 6443
+        {{- if .Values.kcp.profiling.enabled }}
+        - containerPort: {{ .Values.kcp.profiling.port }}
+          name: profiler
+        {{- end}}
+        command: ["/kcp", "start"]
         args:
-        - start
         - --etcd-servers={{ .Values.kcp.etcd.serverAddress }}
         - --etcd-keyfile=/etc/etcd/tls/server/tls.key
         - --etcd-certfile=/etc/etcd/tls/server/tls.crt
@@ -205,25 +228,27 @@ spec:
         - --client-ca-file=/etc/kcp/tls/server-client/ca.crt
         - --tls-private-key-file=/etc/kcp/tls/server/tls.key
         - --tls-cert-file=/etc/kcp/tls/server/tls.crt
+        {{- if .Values.kcp.logicalClusterAdminFlag }}
+        - --logical-cluster-admin-kubeconfig=/etc/kcp/logical-cluster-admin/kubeconfig/logical-cluster-admin.kubeconfig
+        {{- end }}
         - --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client/ca.crt
         - --requestheader-username-headers=X-Remote-User
         - --requestheader-group-headers=X-Remote-Group
         - --root-directory=/etc/kcp/config
-        - --run-virtual-workspaces=false
         - --shard-base-url=https://kcp:6443
         - --shard-external-url=https://$(EXTERNAL_HOSTNAME):443
         - --external-hostname=$(EXTERNAL_HOSTNAME):443
-        - --shard-virtual-workspace-url=https://$(EXTERNAL_HOSTNAME):443
         - --root-ca-file=/etc/kcp/tls/ca/root-ca.pem
         {{- if .Values.oidc }}
         - --oidc-issuer-url={{ .Values.oidc.issuerUrl }}
         - --oidc-client-id={{ .Values.oidc.clientId }}
         - --oidc-groups-claim={{ .Values.oidc.groupClaim }}
         - --oidc-username-claim={{ .Values.oidc.usernameClaim }}
-        - "--oidc-username-prefix={{ .Values.oidc.usernamePrefix }}"
-        - "--oidc-groups-prefix={{ .Values.oidc.groupsPrefix }}"
+        -  --oidc-username-prefix={{ .Values.oidc.usernamePrefix }}
+        -  --oidc-groups-prefix={{ .Values.oidc.groupsPrefix }}
         {{- end }}
         - --v={{ .Values.kcp.v }}
+        - --logging-format=json
         {{- if .Values.audit.enabled }}
         - --audit-log-maxage={{ .Values.audit.log.maxAge }}
         - --audit-log-maxbackup={{ .Values.audit.log.maxBackup }}
@@ -231,18 +256,23 @@ spec:
         - --audit-log-path={{ .Values.audit.log.dir }}/kcp.log
         - --audit-policy-file={{ .Values.audit.policy.dir }}/{{ .Values.audit.policy.fileName }}
         - --audit-log-compress
+        - --audit-log-format=json
         {{- end }}
         {{- if .Values.kcp.profiling.enabled }}
-        - --profiler-address=localhost:{{- .Values.kcp.profiling.port -}}
+        - --profiler-address=0.0.0.0:{{- .Values.kcp.profiling.port -}}
         {{- end }}
         {{- range .Values.kcp.extraFlags }}
-        - {{ . }}
+        {{ . }}
         {{- end }}
         env:
         - name: EXTERNAL_HOSTNAME
           value: {{ required "A valid external hostname is required" .Values.externalHostname }}
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: requests.memory
         livenessProbe:
-          failureThreshold: 3
+          failureThreshold: 6
           httpGet:
             path: livez
             port: 6443
@@ -260,20 +290,28 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 10
           successThreshold: 1
-          failureThreshold: 18
+          failureThreshold: 36
         readinessProbe:
-          failureThreshold: 3
+          failureThreshold: 6
           httpGet:
             path: readyz
             port: 6443
             scheme: HTTPS
         resources:
           limits:
+            {{- if .Values.kcp.cpuLimit }}
             cpu: '{{ .Values.kcp.cpuLimit }}'
+            {{- end }}
+            {{- if .Values.kcp.memoryLimit }}
             memory: '{{ .Values.kcp.memoryLimit }}'
+            {{- end }}
           requests:
+            {{- if .Values.kcp.cpuRequest }}
             cpu: '{{ .Values.kcp.cpuRequest }}'
+            {{- end }}
+            {{- if .Values.kcp.memoryRequest }}
             memory: '{{ .Values.kcp.memoryRequest }}'
+            {{- end }}
         volumeMounts:
         - name: etcd-certs
           mountPath: /etc/etcd/tls/server
@@ -281,10 +319,14 @@ spec:
           mountPath: /etc/kcp/tls/server
         - name: kcp-server-client-ca
           mountPath: /etc/kcp/tls/server-client
-        - name: kcp-requestheader-client-ca 
+        - name: kcp-requestheader-client-ca
           mountPath: /etc/kcp/tls/requestheader-client
         - name: kubeconfig
           mountPath: /etc/kcp/config
+        - name: logical-cluster-admin-client-cert-for-kubeconfig
+          mountPath: /etc/kcp/logical-cluster-admin/client-cert-for-kubeconfig
+        - name: logical-cluster-admin-kubeconfig
+          mountPath: /etc/kcp/logical-cluster-admin/kubeconfig
         {{- if .Values.audit.enabled }}
         - name: audit-log
           mountPath: {{ .Values.audit.log.dir }}
@@ -293,73 +335,6 @@ spec:
         {{- end }}
         - name: root-ca-file
           mountPath: /etc/kcp/tls/ca
-      - name: virtual-workspaces
-        image: {{ .Values.virtualWorkspaces.image }}:{{ .Values.virtualWorkspaces.tag }}
-        ports:
-        - containerPort: 6444
-        command:
-        - sh
-        - -c
-        - >
-          cat /etc/kcp/config/admin.kubeconfig | sed -e 's;://\([^/]*\);://localhost:6443;' -e 's;current-context: root;current-context: system:admin;' > /etc/kcp/config/localhost.kubeconfig &&
-          exec /usr/bin/virtual-workspaces
-          workspaces
-          --kubeconfig=/etc/kcp/config/localhost.kubeconfig
-          --authentication-kubeconfig=/etc/kcp/config/localhost.kubeconfig
-          --authentication-skip-lookup
-          --client-ca-file=/etc/kcp/tls/server-client/ca.crt
-          --tls-private-key-file=/etc/kcp/tls/server/tls.key
-          --tls-cert-file=/etc/kcp/tls/server/tls.crt
-          --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client/ca.crt
-          --requestheader-username-headers=X-Remote-User
-          --requestheader-group-headers=X-Remote-Group
-          --secure-port=6444
-          --v={{ .Values.kcp.v }}
-          {{- if .Values.virtualWorkspaces.profiling.enabled }}
-          --profiler-address=localhost:{{- .Values.virtualWorkspaces.profiling.port -}}
-          {{- end }}
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: livez
-            port: 6444
-            scheme: HTTPS
-          initialDelaySeconds: 45
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 10
-        startupProbe:
-          httpGet:
-            path: readyz
-            port: 6444
-            scheme: HTTPS
-          initialDelaySeconds: 10
-          timeoutSeconds: 1
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 18
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: readyz
-            port: 6444
-            scheme: HTTPS
-        resources:
-          limits:
-            cpu: '{{ .Values.virtualWorkspaces.cpuLimit }}'
-            memory: '{{ .Values.virtualWorkspaces.memoryLimit }}'
-          requests:
-            cpu: '{{ .Values.virtualWorkspaces.cpuRequest }}'
-            memory: '{{ .Values.virtualWorkspaces.memoryRequest }}'
-        volumeMounts:
-        - name: virtual-workspaces-certs
-          mountPath: /etc/kcp/tls/server
-        - name: kcp-server-client-ca
-          mountPath: /etc/kcp/tls/server-client
-        - name: kcp-requestheader-client-ca 
-          mountPath: /etc/kcp/tls/requestheader-client
-        - name: kubeconfig
-          mountPath: /etc/kcp/config
       volumes:
       - name: etcd-certs
         secret:
@@ -382,6 +357,20 @@ spec:
           items:
           - key: ca.crt
             path: ca.crt
+      - name: logical-cluster-admin-client-cert-for-kubeconfig
+        secret:
+          secretName: logical-cluster-admin-client-cert-for-kubeconfig
+          items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+      - name: logical-cluster-admin-kubeconfig
+        secret:
+          secretName: logical-cluster-admin-kubeconfig
+          items:
+            - key: kubeconfig
+              path: logical-cluster-admin.kubeconfig
       - name: kubeconfig
         persistentVolumeClaim:
           claimName: kcp

--- a/charts/kcp/templates/logical-cluster-admin-kubeconfig.yaml
+++ b/charts/kcp/templates/logical-cluster-admin-kubeconfig.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority: /etc/kcp/tls/server-client/ca.crt
+        server: https://kcp:6443
+      name: logical-cluster:admin
+    contexts:
+    - context:
+        cluster: logical-cluster:admin
+        user: logical-cluster-admin
+      name: logical-cluster
+    current-context: logical-cluster
+    kind: Config
+    preferences: {}
+    users:
+    - name: logical-cluster-admin
+      user:
+        client-certificate: /etc/kcp/logical-cluster-admin/client-cert-for-kubeconfig/tls.crt
+        client-key: /etc/kcp/logical-cluster-admin/client-cert-for-kubeconfig/tls.key
+kind: Secret
+metadata:
+  name: logical-cluster-admin-kubeconfig
+type: Opaque

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -3,34 +3,38 @@ etcd:
   enabled: true
   image: quay.io/coreos/etcd
   tag: v3.5.4
-  memoryLimit: 4Gi
+  cpuRequest: 500m
+  memoryLimit: 20Gi
+  memoryRequest: 2Gi
   volumeSize: 8Gi
   profiling:
     enabled: false
 kcp:
-  image: registry.ci.openshift.org/kcp/kcp
+  image: ghcr.io/kcp-dev/kcp
   tag: latest
-  v: "4"
+  v: "3"
+  logicalClusterAdminFlag: true
   memoryLimit: 20Gi
-  cpuRequest: 500m
-  memoryRequest: 4Gi
+  memoryRequest: 5Gi
+  cpuRequest: 100m
+  volumeClassName: gp2-csi
   etcd:
     serverAddress: https://etcd:2379
     clientCertificate:
       issuer: etcd-client-issuer
       commonName: root
   volumeSize: 1Gi
-  volumeClassName: ""
-  extraFlags: []  # Format is raw flag, e.g. --virtual-server-url=https://abc.xyz:443
+  extraFlags: []
   profiling:
     enabled: false
     port: 6060
 kcpFrontProxy:
-  image: registry.ci.openshift.org/kcp/kcp-front-proxy
+  image: ghcr.io/kcp-dev/kcp
   tag: latest
   v: "4"
+  shardsKubeConfigFlag: true
   openshiftRoute:
-    enabled: false
+    enabled: true
   ingress:
     enabled: false
     annotations: {}
@@ -39,23 +43,23 @@ kcpFrontProxy:
     enabled: false
     className: ""
   certificate:
-    issuerSpec: {}
+    issuerSpec:
+      acme:
+        server: https://acme-v02.api.letsencrypt.org/directory
+        privateKeySecretRef:
+          name: kcp-front-proxy-issuer-account-key
+        solvers:
+        - http01:
+            ingress:
+              serviceType: ClusterIP
   profiling:
     enabled: false
     port: 6060
-virtualWorkspaces:
-  image: registry.ci.openshift.org/kcp/virtual-workspaces
-  tag: latest
-  memoryLimit: 10Gi
-  cpuRequest: 100m
-  memoryRequest: 2Gi
-  profiling:
-    enabled: false
-    port: 6061
+oidc: {}
 audit:
-  enabled: true
+  enabled: false
   volumeSize: 1Gi
-  volumeClassName: ""
+  volumeClassName: "gp2-csi"
   policy:
     dir: /etc/kcp/audit
     fileName: audit-policy.yml
@@ -75,6 +79,5 @@ certificates:
     algorithm: RSA
     size: 2048
   subject: {}
-oidc: {}
 githubUserEditAccess:
 - test


### PR DESCRIPTION
This updates the templates to align with a fork we've been maintaining, I tested this and it seems to work OK

So far I've only tested on openshift (4.12, with RH version of the cert-manager operator installed), with a config like:

```
$ cat myvalues.yaml 
externalHostname: "kcp-front-proxy.<cluster ingress DNS name>"
kcpFrontProxy:
  openshiftRoute:
    enabled: true
```

And installed like `helm install kcp ./kcp --values ./myvalues.yaml --namespace kcp --create-namespace`

We'll need some follow-up testing to ensure the other ingress options work, but hopefully this is a step in the right direction to enable easier testing with KCP main.
