### PR TITLE
Don't enable openshiftRoute by default

### DIFF
--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -34,7 +34,7 @@ kcpFrontProxy:
   v: "4"
   shardsKubeConfigFlag: true
   openshiftRoute:
-    enabled: true
+    enabled: false
   ingress:
     enabled: false
     annotations: {}


### PR DESCRIPTION
This is a mistake introduced via #24 - we should
disable all ingress options by default, then users can choose one which suits their environment