### PR TITLE
Auth token support + kind cluster helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.kubeconfig

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- KCP Helm Charts
+# KCP Helm Charts
 
 Repository for KCP helm charts.
 

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -269,6 +269,9 @@ spec:
         -  --oidc-username-prefix={{ .Values.oidc.usernamePrefix }}
         -  --oidc-groups-prefix={{ .Values.oidc.groupsPrefix }}
         {{- end }}
+        {{- if .Values.kcp.tokenAuth.enabled }}
+        - --token-auth-file=/etc/kcp/token-auth/{{ .Values.kcp.tokenAuth.fileName }}
+        {{- end }}
         - --v={{ .Values.kcp.v }}
         - --logging-format=json
         {{- if .Values.audit.enabled }}
@@ -347,6 +350,10 @@ spec:
           mountPath: /etc/kcp/tls/requestheader-client
         - name: kubeconfig
           mountPath: /etc/kcp/config
+        {{- if .Values.kcp.tokenAuth.enabled }}
+        - name: kcp-token-auth-file
+          mountPath: /etc/kcp/token-auth
+        {{- end}}
         - name: logical-cluster-admin-client-cert-for-kubeconfig
           mountPath: /etc/kcp/logical-cluster-admin/client-cert-for-kubeconfig
         - name: logical-cluster-admin-kubeconfig
@@ -427,6 +434,11 @@ spec:
         persistentVolumeClaim:
           claimName: kcp-audit-logs
       {{- end }}
+      {{- if .Values.kcp.tokenAuth.enabled }}
+      - name: kcp-token-auth-file
+        secret:
+          secretName: kcp-token-auth-file
+      {{- end }}
       - name: root-ca-file
         configMap:
           name: kcp-root-ca
@@ -438,3 +450,14 @@ metadata:
 data:
   {{ .Values.audit.policy.fileName }}: |
     {{- .Values.audit.policy.config | nindent 4 }}
+
+{{- if .Values.kcp.tokenAuth.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kcp-token-auth-file
+stringData:
+  {{ .Values.kcp.tokenAuth.fileName }}: |
+    {{- .Values.kcp.tokenAuth.config | nindent 4 }}
+{{- end}}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -29,6 +29,12 @@ kcp:
   profiling:
     enabled: false
     port: 6060
+  tokenAuth:
+    enabled: false
+    fileName: auth-token.csv
+    config: |
+        user-1-token,user-1,1111-1111-1111-1111,"team-1"
+        admin-token,admin,5555-5555-5555-5555,"system:masters"
 kcpFrontProxy:
   image: ghcr.io/kcp-dev/kcp
   tag: latest
@@ -44,7 +50,7 @@ kcpFrontProxy:
     enabled: false
     className: ""
   certificate:
-    issuerSpec:
+  issuerSpec:
       acme:
         server: https://acme-v02.api.letsencrypt.org/directory
         privateKeySecretRef:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -50,15 +50,7 @@ kcpFrontProxy:
     enabled: false
     className: ""
   certificate:
-  issuerSpec:
-      acme:
-        server: https://acme-v02.api.letsencrypt.org/directory
-        privateKeySecretRef:
-          name: kcp-front-proxy-issuer-account-key
-        solvers:
-        - http01:
-            ingress:
-              serviceType: ClusterIP
+    issuerSpec: {selfSigned: {}}
   profiling:
     enabled: false
     port: 6060

--- a/hack/generate-admin-kubeconfig.sh
+++ b/hack/generate-admin-kubeconfig.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+hostname=$(cat ./hack/kind-values.yaml | grep externalHostname | cut -d" " -f2- | tr -d '"')
+
+cat << EOF > kcp.kubeconfig
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://${hostname}/clusters/root
+  name: kind-kcp
+contexts:
+- context:
+    cluster: kind-kcp
+    user: kind-kcp
+  name: kind-kcp
+current-context: kind-kcp
+kind: Config
+preferences: {}
+users:
+- name: kind-kcp
+  user:
+    token: admin-token
+EOF
+
+
+echo "Kubeconfig file created at kcp.kubeconfig"
+echo ""
+echo "export KUBECONFIG=kcp.kubeconfig"
+echo ""

--- a/hack/kind-setup.sh
+++ b/hack/kind-setup.sh
@@ -25,9 +25,10 @@ export KUBECONFIG=./${CLUSTER_NAME}.kubeconfig
 echo "Installing ingress"
 
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-kubectl label nodes faros-control-plane node-role.kubernetes.io/control-plane-
+kubectl label nodes kcp-control-plane node-role.kubernetes.io/control-plane-
 
 echo "Waiting for the ingress controller to become ready..."
+sleep 5
 kubectl --context "${KUBECTL_CONTEXT}" -n ingress-nginx wait --for=condition=Ready pod -l app.kubernetes.io/component=controller --timeout=5m
 
 

--- a/hack/kind-setup.sh
+++ b/hack/kind-setup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+if [ ! -f "/usr/local/bin/kind" ]; then
+ echo "Installing KIND"
+ curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64
+ chmod +x ./kind
+ sudo mv ./kind /usr/local/bin/kind
+else
+    echo "KIND already installed"
+fi
+
+CLUSTER_NAME=${CLUSTER_NAME:-kcp}
+
+if ! kind get clusters | grep -w -q "${CLUSTER_NAME}"; then
+kind create cluster --name ${CLUSTER_NAME} \
+     --kubeconfig ./${CLUSTER_NAME}.kubeconfig \
+     --config ./hack/kind/config.yaml
+else
+    echo "Cluster already exists"
+fi
+
+export KUBECONFIG=./${CLUSTER_NAME}.kubeconfig
+
+echo "Installing ingress"
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+kubectl label nodes faros-control-plane node-role.kubernetes.io/control-plane-
+
+echo "Waiting for the ingress controller to become ready..."
+kubectl --context "${KUBECTL_CONTEXT}" -n ingress-nginx wait --for=condition=Ready pod -l app.kubernetes.io/component=controller --timeout=5m
+
+
+echo "Installing cert-manager"
+
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.crds.yaml
+helm install \
+  --wait \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.9.1
+
+
+echo "Install KCP"
+
+mkdir -p ./dev
+
+helm upgrade -i kcp ./charts/kcp \
+     --values ./hack/kind-values.yaml \
+     --namespace kcp \
+     --create-namespace
+
+echo "Generate KCP admin kubeconfig"
+./hack/generate-admin-kubeconfig.sh
+
+echo "Check /etc/hosts for kcp.dev.local"
+if ! grep -q kcp.dev.local /etc/hosts; then
+    echo "127.0.0.1 kcp.dev.local" | sudo tee -a /etc/hosts
+else
+    echo "kcp.dev.local already exists in /etc/hosts"
+fi

--- a/hack/kind-values.yaml
+++ b/hack/kind-values.yaml
@@ -1,0 +1,16 @@
+externalHostname: "kcp.dev.local"
+kcp:
+  volumeClassName: "standard"
+  tokenAuth:
+    enabled: true
+kcpFrontProxy:
+  openshiftRoute:
+    enabled: false
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  certificate:
+    issuerSpec:
+      selfSigned: {}

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -1,0 +1,29 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  EphemeralContainers: true
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      "enable-admission-plugins": NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.24.2
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP


### PR DESCRIPTION
In this PR:
1. Rename `readme.md` to `README.md` (sorry, nitpicking)
2. Add the ability to deploy with a token file
3. Remove lets encrypt production issuer as default (does not work well with kind)
4. Add helper script to deploy end-to-end kind cluster with self-signed certificates and localhost ingress (nginx)
