### PR TITLE
Tag 0.2.5

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 type: application
-version: 0.2.4
-appVersion: "0.8"
+version: 0.2.5
+appVersion: "0.10"


### PR DESCRIPTION
The [chart-releaser job is failing](https://github.com/kcp-dev/helm-charts/actions/runs/4173306995/jobs/7225475690) so bump the version such that the released chart contains recent fixes

I also bumped `appVersion` but I think we will require `latest` e.g main images until 0.11 is released, since we've not backported https://github.com/kcp-dev/kcp/pull/2659