### PR TITLE
Add external-logical-cluster-admin

### DIFF
--- a/charts/kcp/templates/external-logical-cluster-admin-kubeconfig.yaml
+++ b/charts/kcp/templates/external-logical-cluster-admin-kubeconfig.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority: /etc/kcp-front-proxy/tls/tls.crt
+        server: https://{{ .Values.externalHostname }}:443
+      name: external-logical-cluster-admin
+    contexts:
+    - context:
+        cluster: external-logical-cluster-admin
+        user: external-logical-cluster-admin
+      name: external-logical-cluster
+    current-context: external-logical-cluster
+    kind: Config
+    preferences: {}
+    users:
+    - name: external-logical-cluster-admin
+      user:
+        client-certificate: /etc/kcp/external-logical-cluster-admin/client-cert-for-kubeconfig/tls.crt
+        client-key: /etc/kcp/external-logical-cluster-admin/client-cert-for-kubeconfig/tls.key
+kind: Secret
+metadata:
+  name: external-logical-cluster-admin-kubeconfig
+type: Opaque

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -147,6 +147,25 @@ spec:
   issuerRef:
     name: kcp-server-client-issuer
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: external-logical-cluster-admin-client-cert-for-kubeconfig
+spec:
+  secretName: external-logical-cluster-admin-client-cert-for-kubeconfig
+  duration: 8760h0m0s # 365d
+  renewBefore: 360h0m0s # 15d
+  commonName: external-logical-cluster-admin
+  subject:
+    organizations:
+      - "system:kcp:external-logical-cluster-admin"
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  issuerRef:
+    name: kcp-server-client-issuer
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -231,6 +250,9 @@ spec:
         {{- if .Values.kcp.logicalClusterAdminFlag }}
         - --logical-cluster-admin-kubeconfig=/etc/kcp/logical-cluster-admin/kubeconfig/logical-cluster-admin.kubeconfig
         {{- end }}
+        {{- if .Values.kcp.externalLogicalClusterAdminFlag }}
+        - --external-logical-cluster-admin-kubeconfig=/etc/kcp/external-logical-cluster-admin/kubeconfig/external-logical-cluster-admin.kubeconfig
+        {{- end }}
         - --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client/ca.crt
         - --requestheader-username-headers=X-Remote-User
         - --requestheader-group-headers=X-Remote-Group
@@ -313,6 +335,8 @@ spec:
             memory: '{{ .Values.kcp.memoryRequest }}'
             {{- end }}
         volumeMounts:
+        - name: kcp-front-proxy-cert
+          mountPath: /etc/kcp-front-proxy/tls
         - name: etcd-certs
           mountPath: /etc/etcd/tls/server
         - name: kcp-certs
@@ -327,6 +351,10 @@ spec:
           mountPath: /etc/kcp/logical-cluster-admin/client-cert-for-kubeconfig
         - name: logical-cluster-admin-kubeconfig
           mountPath: /etc/kcp/logical-cluster-admin/kubeconfig
+        - name: external-logical-cluster-admin-client-cert-for-kubeconfig
+          mountPath: /etc/kcp/external-logical-cluster-admin/client-cert-for-kubeconfig
+        - name: external-logical-cluster-admin-kubeconfig
+          mountPath: /etc/kcp/external-logical-cluster-admin/kubeconfig
         {{- if .Values.audit.enabled }}
         - name: audit-log
           mountPath: {{ .Values.audit.log.dir }}
@@ -336,6 +364,9 @@ spec:
         - name: root-ca-file
           mountPath: /etc/kcp/tls/ca
       volumes:
+      - name: kcp-front-proxy-cert
+        secret:
+          secretName: kcp-front-proxy-cert
       - name: etcd-certs
         secret:
           secretName: kcp-etcd-client
@@ -371,6 +402,20 @@ spec:
           items:
             - key: kubeconfig
               path: logical-cluster-admin.kubeconfig
+      - name: external-logical-cluster-admin-client-cert-for-kubeconfig
+        secret:
+          secretName: external-logical-cluster-admin-client-cert-for-kubeconfig
+          items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+      - name: external-logical-cluster-admin-kubeconfig
+        secret:
+          secretName: external-logical-cluster-admin-kubeconfig
+          items:
+            - key: kubeconfig
+              path: external-logical-cluster-admin.kubeconfig
       - name: kubeconfig
         persistentVolumeClaim:
           claimName: kcp

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -14,6 +14,7 @@ kcp:
   tag: latest
   v: "3"
   logicalClusterAdminFlag: true
+  externalLogicalClusterAdminFlag: true
   memoryLimit: 20Gi
   memoryRequest: 5Gi
   cpuRequest: 100m


### PR DESCRIPTION
Currently the logical cluster admin kubeconfig is used to access both the [external front-proxy endpoint](https://github.com/kcp-dev/kcp/blob/main/pkg/reconciler/tenancy/workspace/workspace_controller.go#L194..L195), and also the [shard directly via the baseURL](https://github.com/kcp-dev/kcp/blob/main/pkg/reconciler/tenancy/workspace/workspace_reconcile.go#L71..L72) - this won't work in the case where different CA certs are used for shard and front-proxy such as in the templates maintained in this repo.

Requires https://github.com/kcp-dev/kcp/pull/2882

Fixes: #32