### PR TITLE
Standardize resource configuration

### DIFF
--- a/charts/kcp/templates/etcd.yaml
+++ b/charts/kcp/templates/etcd.yaml
@@ -154,21 +154,10 @@ spec:
               mountPath: /etc/etcd/tls/peer
             - name: server-certs
               mountPath: /etc/etcd/tls/server
+          {{- with .Values.etcd.resources }}
           resources:
-            limits:
-              {{- if .Values.etcd.cpuLimit }}
-              cpu: '{{ .Values.etcd.cpuLimit }}'
-              {{- end }}
-              {{- if .Values.etcd.memoryLimit }}
-              memory: '{{ .Values.etcd.memoryLimit }}'
-              {{- end }}
-            requests:
-              {{- if .Values.etcd.cpuRequest }}
-              cpu: '{{ .Values.etcd.cpuRequest }}'
-              {{- end }}
-              {{- if .Values.etcd.memoryRequest }}
-              memory: '{{ .Values.etcd.memoryRequest }}'
-              {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /bin/sh
             - -c

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -273,12 +273,10 @@ spec:
             path: readyz
             port: 8443
             scheme: HTTPS
+        {{- with .Values.kcpFrontProxy.resources }}
         resources:
-          limits:
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 128Mi
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: kcp-front-proxy-cert
           mountPath: /etc/kcp-front-proxy/tls

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -322,21 +322,10 @@ spec:
             path: readyz
             port: 6443
             scheme: HTTPS
+        {{- with .Values.kcp.resources }}
         resources:
-          limits:
-            {{- if .Values.kcp.cpuLimit }}
-            cpu: '{{ .Values.kcp.cpuLimit }}'
-            {{- end }}
-            {{- if .Values.kcp.memoryLimit }}
-            memory: '{{ .Values.kcp.memoryLimit }}'
-            {{- end }}
-          requests:
-            {{- if .Values.kcp.cpuRequest }}
-            cpu: '{{ .Values.kcp.cpuRequest }}'
-            {{- end }}
-            {{- if .Values.kcp.memoryRequest }}
-            memory: '{{ .Values.kcp.memoryRequest }}'
-            {{- end }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: kcp-front-proxy-cert
           mountPath: /etc/kcp-front-proxy/tls

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -3,9 +3,13 @@ etcd:
   enabled: true
   image: quay.io/coreos/etcd
   tag: v3.5.4
-  cpuRequest: 500m
-  memoryLimit: 20Gi
-  memoryRequest: 2Gi
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      # cpu: 1
+     memory: 20Gi
   volumeSize: 8Gi
   profiling:
     enabled: false
@@ -15,9 +19,13 @@ kcp:
   v: "3"
   logicalClusterAdminFlag: true
   externalLogicalClusterAdminFlag: true
-  memoryLimit: 20Gi
-  memoryRequest: 5Gi
-  cpuRequest: 100m
+  resources:
+    requests:
+      memory: 5Gi
+      cpu: 100m
+    limits:
+      # cpu: 1
+      memory: 20Gi
   volumeClassName: gp2-csi
   etcd:
     serverAddress: https://etcd:2379

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -62,6 +62,13 @@ kcpFrontProxy:
   profiling:
     enabled: false
     port: 6060
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      # cpu: 1
+      memory: 1Gi
 oidc: {}
 audit:
   enabled: false


### PR DESCRIPTION
I've never seen the way that the `kcp` Helm chart configures resources. This updates `values.yaml` and affected templates to use a de-facto standard for Helm charts, used in popular Helm charts like [cert-manager](https://github.com/cert-manager/cert-manager/tree/master/deploy/charts/cert-manager) or [ingress-nginx](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx).