### PR TITLE
Add securityContexts to confine kcp pods and set fsGroup correctly

### DIFF
--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -260,6 +260,9 @@ spec:
       labels:
         app: kcp-front-proxy
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       {{- if .Values.kcpFrontProxy.hostAliases.enabled }}
       hostAliases:
         {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 6 }}

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -250,6 +250,11 @@ spec:
       labels:
         app: kcp
     spec:
+      securityContext:
+        # this matches the group id as set in the kcp Dockerfile.
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       {{- if .Values.kcp.hostAliases.enabled }}
       hostAliases:
         {{- toYaml .Values.kcp.hostAliases.values | nindent 6 }}


### PR DESCRIPTION
This PR adds what I mentioned over in the previous PR (https://github.com/kcp-dev/helm-charts/pull/38#discussion_r1253102023) to the kcp pod templates. I took the liberty to also enable seccomp profiles by default, a small security improvements usually recommended. I don't think kcp does any crazy syscalls that we would need to allow outside of seccomp.

The fsGroup is chosen based [on the kcp Dockerfile](https://github.com/kcp-dev/kcp/blob/ae902beedc1f45ec37afc87881f3f9d2473bf927/Dockerfile#L64) setting the image up to use this user and group ID by default. For some environments, this is a necessary setting so the mounted PVC gets reconfigured correctly.