### PR TITLE
Add chart metadata to Chart.yaml

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -1,6 +1,20 @@
 apiVersion: v2
 name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
-type: application
+
+# version information
 version: 0.2.5
 appVersion: "0.10"
+
+# optional metadata
+type: application
+home: https://kcp.io
+keywords:
+  - kcp
+  - kubernetes
+  - multitenancy
+  - controlplane
+sources:
+  - https://github.com/kcp-dev/helm-charts
+  - https://github.com/kcp-dev/kcp
+icon: https://raw.githubusercontent.com/kcp-dev/kcp/main/contrib/logo/blue-green.svg


### PR DESCRIPTION
Low priority PR, but I figured it would be nice to publish some metadata as part of the Helm chart.