### PR TITLE
set HTTPS backend annotation on Ingress resource by default

### DIFF
--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -62,6 +62,9 @@ kcpFrontProxy:
     annotations:
       kubernetes.io/ingress.class: "nginx"
       acme.cert-manager.io/http01-edit-in-place: "true"
+      # this is ingress-controller-specific and might need configuration
+      # depending on the ingress-controller in use.
+      nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     secret: ""
   gateway:
     enabled: false


### PR DESCRIPTION
Because the kcp-front-proxy serves HTTPS by default, installing the chart without customizing the Ingress annotations will result in an error looking like

```
Client sent an HTTP request to an HTTPS server.
```

While this setting depends on the ingress controller in use, we already set `kubernetes.io/ingress.class=nginx`, so the general expectation of the default Helm values is that nginx-ingress-controller is deployed. Adding this annotation to the default set makes that implicit reference setup fully work.

In addition, this PR adds a comment so that users of other ingress controllers can look up what their implementation requires for similar functionality.