### PR TITLE
wrap oidc prefix flag values into single quotes

### DIFF
--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -295,8 +295,8 @@ spec:
         - --oidc-client-id={{ .Values.oidc.clientId }}
         - --oidc-groups-claim={{ .Values.oidc.groupClaim }}
         - --oidc-username-claim={{ .Values.oidc.usernameClaim }}
-        - --oidc-username-prefix={{ .Values.oidc.usernamePrefix }}
-        - --oidc-groups-prefix={{ .Values.oidc.groupsPrefix }}
+        - --oidc-username-prefix='{{ .Values.oidc.usernamePrefix }}'
+        - --oidc-groups-prefix='{{ .Values.oidc.groupsPrefix }}'
         {{- if .Values.oidc.caSecretName }}
         - --oidc-ca-file=/etc/kcp/tls/oidc/ca.crt
         {{- end }}

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -301,8 +301,8 @@ spec:
         - --oidc-client-id={{ .Values.oidc.clientId }}
         - --oidc-groups-claim={{ .Values.oidc.groupClaim }}
         - --oidc-username-claim={{ .Values.oidc.usernameClaim }}
-        - --oidc-username-prefix={{ .Values.oidc.usernamePrefix }}
-        - --oidc-groups-prefix={{ .Values.oidc.groupsPrefix }}
+        - --oidc-username-prefix='{{ .Values.oidc.usernamePrefix }}'
+        - --oidc-groups-prefix='{{ .Values.oidc.groupsPrefix }}'
         {{- if .Values.oidc.caSecretName }}
         - --oidc-ca-file=/etc/kcp/tls/oidc/ca.crt
         {{- end }}


### PR DESCRIPTION
This is a fix for when the oidc username group prefixes values include a trailing colon. Helm really does not like that for some reason (or is it Kubernetes in the first place?), so this PR wraps the two values into single quotes to make it clear the colon is no part of YAML structure.

Example values that caused this problem:

```yaml
oidc:
  usernamePrefix: 'oidc:'
  groupsPrefix: 'oidc:'
```