### PR TITLE
add configuration options to `kcp-front-proxy` Service to expose it directly

### DIFF
--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -221,7 +221,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kcp-front-proxy
+  {{- with .Values.kcpFrontProxy.service.annotations }}
+  annotations: 
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  type: {{ .Values.kcpFrontProxy.service.type }}
   ports:
     - protocol: TCP
       name: kcp-front-proxy

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -293,8 +293,8 @@ spec:
         - --root-directory=/etc/kcp/config
         - --shard-virtual-workspace-ca-file=/etc/kcp/tls/ca/root-ca.pem
         - --shard-base-url=https://kcp:6443
-        - --shard-external-url=https://$(EXTERNAL_HOSTNAME):443
-        - --external-hostname=$(EXTERNAL_HOSTNAME):443
+        - --shard-external-url=https://$(EXTERNAL_HOSTNAME):$(EXTERNAL_PORT)
+        - --external-hostname=$(EXTERNAL_HOSTNAME):$(EXTERNAL_PORT)
         - --root-ca-file=/etc/kcp/tls/ca/root-ca.pem
         {{- if .Values.oidc.enabled }}
         - --oidc-issuer-url={{ .Values.oidc.issuerUrl }}
@@ -330,6 +330,8 @@ spec:
         env:
         - name: EXTERNAL_HOSTNAME
           value: {{ required "A valid external hostname is required" .Values.externalHostname }}
+        - name: EXTERNAL_PORT
+          value: {{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}
         - name: GOMEMLIMIT
           valueFrom:
             resourceFieldRef:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -66,6 +66,11 @@ kcpFrontProxy:
   gateway:
     enabled: false
     className: ""
+  service:
+    annotations: {}
+    # set this to LoadBalancer if you want to publish kcp-front-proxy
+    # directly instead of going via Route/Ingress/Gateway resources.
+    type: LoadBalancer
   certificate:
     issuer: kcp-selfsigned-issuer
   profiling:


### PR DESCRIPTION
The current options to expose the front proxy to the Internet are OpenShift Route, Ingress or Gateway. This PR adds some configuration that allows to reconfigure the `kcp-front-proxy` Service to be a load balancer directly.

To account for port changes, this PR also automatically reconfigures the `kcp` Deployment to make sure the Service port (8443) is respected for external URLs if `LoadBalancer` is chosen. 