### PR TITLE
🐛  wrap EXTERNAL_PORT to make sure it's seen as string

### DIFF
--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -331,7 +331,7 @@ spec:
         - name: EXTERNAL_HOSTNAME
           value: {{ required "A valid external hostname is required" .Values.externalHostname }}
         - name: EXTERNAL_PORT
-          value: {{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}
+          value: "{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}"
         - name: GOMEMLIMIT
           valueFrom:
             resourceFieldRef:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -73,7 +73,7 @@ kcpFrontProxy:
     annotations: {}
     # set this to LoadBalancer if you want to publish kcp-front-proxy
     # directly instead of going via Route/Ingress/Gateway resources.
-    type: LoadBalancer
+    type: ClusterIP
   certificate:
     issuer: kcp-selfsigned-issuer
   profiling:


### PR DESCRIPTION
I keep forgetting that YAML does this - this fixes an issue I added in #45.

This produces failed upgrades with errors like this:

```
 json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
 ```
 
 In addition, I committed the `type: LoadBalancer` change that was only meant for local testing. My bad, fixing this as well.