### PR TITLE
change port in external-logical-cluster-admin kubeconfig when exposing front proxy directly

### DIFF
--- a/charts/kcp/templates/external-logical-cluster-admin-kubeconfig.yaml
+++ b/charts/kcp/templates/external-logical-cluster-admin-kubeconfig.yaml
@@ -5,7 +5,7 @@ stringData:
     clusters:
     - cluster:
         certificate-authority: /etc/kcp-front-proxy/tls/tls.crt
-        server: https://{{ .Values.externalHostname }}:443
+        server: https://{{ .Values.externalHostname }}:{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}
       name: external-logical-cluster-admin
     contexts:
     - context:


### PR DESCRIPTION
When exporting the front proxy directly via a `LoadBalancer` service, this kubeconfig needs to be updated to use the correct external port. This matches the `EXTERNAL_PORT` environment variable set in the `kcp` Deployment, but we cannot read from it here, so we need to replicate the logic.