### PR TITLE
Enable use of embedded etcd

### DIFF
--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -113,6 +113,7 @@ spec:
   {{- end }}
   issuerRef:
     name: kcp-server-issuer
+{{- if .Values.etcd.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -129,6 +130,7 @@ spec:
     - client auth
   issuerRef:
     name: {{ .Values.kcp.etcd.clientCertificate.issuer }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -272,9 +274,11 @@ spec:
         command: ["/kcp", "start"]
         args:
         - --etcd-servers={{ .Values.kcp.etcd.serverAddress }}
+        {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}
         - --etcd-keyfile=/etc/etcd/tls/server/tls.key
         - --etcd-certfile=/etc/etcd/tls/server/tls.crt
         - --etcd-cafile=/etc/etcd/tls/server/ca.crt
+        {{- end }}
         - --client-ca-file=/etc/kcp/tls/server-client/ca.crt
         - --tls-private-key-file=/etc/kcp/tls/server/tls.key
         - --tls-cert-file=/etc/kcp/tls/server/tls.crt
@@ -369,8 +373,10 @@ spec:
         volumeMounts:
         - name: kcp-front-proxy-cert
           mountPath: /etc/kcp-front-proxy/tls
+        {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}
         - name: etcd-certs
           mountPath: /etc/etcd/tls/server
+        {{- end }}
         - name: kcp-certs
           mountPath: /etc/kcp/tls/server
         - name: kcp-server-client-ca
@@ -411,9 +417,11 @@ spec:
       - name: kcp-front-proxy-cert
         secret:
           secretName: kcp-front-proxy-cert
+      {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}
       - name: etcd-certs
         secret:
           secretName: kcp-etcd-client
+      {{- end }}
       - name: kcp-certs
         secret:
           secretName: kcp-cert

--- a/hack/kind-values.yaml
+++ b/hack/kind-values.yaml
@@ -1,8 +1,12 @@
 externalHostname: "kcp.dev.local"
+etcd:
+  enabled: false
 kcp:
   volumeClassName: "standard"
   tokenAuth:
     enabled: true
+  etcd:
+    serverAddress: embedded
 kcpFrontProxy:
   openshiftRoute:
     enabled: false

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -13,7 +13,7 @@ kubeadmConfigPatches:
       "enable-admission-plugins": NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
 nodes:
   - role: control-plane
-    image: kindest/node:v1.24.2
+    image: kindest/node:v1.26.6
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration


### PR DESCRIPTION
Without this PR, setting `etcd.enabled` to `false` and `kcp.etcd.serverAddress` to `embedded` is not enough because it leaves the kcp server hanging due to the absence of the Secret named `kcp-etcd-client`, which is absent because the corresponding Certificate never gets that Secret issued, because it is asking for an issuer that does not exist due to the `etcd.enabled = false` setting.

This PR makes the dependence on the Secret named `kcp-etcd-client` go away if `kcp.etcd.serverAddress` is set to `embedded`, and adds the Certificate named `kcp-etcd-client` to the stuff that goes away if `etcd.enabled` is set to `false`.

Successfully tested with `etcd.enabled = false` and `kcp.etcd.serverAddress = "embedded"`.

Should also be functional with `etcd.enabled = false` and `kcp.etcd.serverAddress` set to some pre-existing etcd cluster and the Secret named `kcp-etcd-client` already existing and holding the TLS credentials needed to access that etcd cluster.