### PR TITLE
Add well-known `app.kubernetes.io` labels to all resources

### DIFF
--- a/charts/kcp/templates/_helpers.tpl
+++ b/charts/kcp/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{- define "kcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.chartName" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "common.labels" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "kcp.chartName" . }}
+{{- end -}}
+
+{{- define "common.labels.selector" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/kcp/templates/certmanagerissuer.yaml
+++ b/charts/kcp/templates/certmanagerissuer.yaml
@@ -5,6 +5,9 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: kcp-letsencrypt-staging
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
 spec:
   acme:
     # You must replace this email address with your own.
@@ -27,6 +30,9 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: kcp-letsencrypt-prod
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
 spec:
   acme:
     # You must replace this email address with your own.
@@ -49,6 +55,9 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: kcp-selfsigned-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
 spec:
   selfSigned: {}
 

--- a/charts/kcp/templates/etcd.yaml
+++ b/charts/kcp/templates/etcd.yaml
@@ -4,6 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: etcd-client-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
 spec:
   isCA: true
   commonName: etcd-client-bootstrap
@@ -19,6 +22,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: etcd-peer-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
 spec:
   isCA: true
   commonName: etcd-peer-bootstrap
@@ -34,6 +40,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: etcd-client-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
 spec:
   ca:
     secretName: etcd-client-bootstrap-secret
@@ -42,6 +51,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: etcd-peer-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
 spec:
   ca:
     secretName: etcd-peer-bootstrap-secret
@@ -50,6 +62,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: etcd
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
 spec:
   secretName: etcd-cert
   duration: 8760h0m0s # 365d
@@ -80,6 +95,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: etcd-peer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
 spec:
   secretName: etcd-peer-cert
   duration: 8760h0m0s # 365d
@@ -110,7 +128,8 @@ kind: Service
 metadata:
   name: etcd
   labels:
-    app: etcd
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
 spec:
   clusterIP: None
   ports:
@@ -126,18 +145,21 @@ kind: StatefulSet
 metadata:
   name: etcd
   labels:
-    app: etcd
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
 spec:
   serviceName: etcd
   selector:
     matchLabels:
-      app: etcd
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "etcd"
   replicas: 3
   template:
     metadata:
       name: etcd
       labels:
-        app: etcd
+        {{- include "common.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "etcd"
     spec:
       containers:
         - name: etcd

--- a/charts/kcp/templates/external-logical-cluster-admin-kubeconfig.yaml
+++ b/charts/kcp/templates/external-logical-cluster-admin-kubeconfig.yaml
@@ -23,4 +23,6 @@ stringData:
 kind: Secret
 metadata:
   name: external-logical-cluster-admin-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/kcp/templates/front-proxy-kubeconfig.yaml
+++ b/charts/kcp/templates/front-proxy-kubeconfig.yaml
@@ -23,4 +23,6 @@ stringData:
 kind: Secret
 metadata:
   name: proxy-kcp-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/kcp/templates/issuer.yaml
+++ b/charts/kcp/templates/issuer.yaml
@@ -2,6 +2,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: kcp-pki-bootstrap
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
 spec:
   selfSigned: {}
 ---
@@ -9,6 +12,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-pki-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
 spec:
   isCA: true
   commonName: kcp-pki-ca
@@ -26,6 +32,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: kcp-pki-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
 spec:
   ca:
     secretName: kcp-pki-ca

--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -4,6 +4,9 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: kcp-front-proxy
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   host: {{ .Values.externalHostname }}
   port:
@@ -22,6 +25,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: kcp-front-proxy
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
   annotations:
     {{- toYaml .Values.kcpFrontProxy.ingress.annotations | nindent 4 }}
 spec:
@@ -49,6 +55,9 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: kcp-front-proxy
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   gatewayClassName: {{ required "gateway.classname is required" .Values.kcpFrontProxy.gateway.className }}
   listeners:
@@ -63,6 +72,9 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TLSRoute
 metadata:
   name: kcp-front-proxy
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   parentRefs:
   - kind: Gateway
@@ -79,6 +91,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-front-proxy
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   secretName: kcp-front-proxy-cert
   duration: 8760h0m0s # 365d
@@ -102,6 +117,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-client-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   isCA: true
   commonName: kcp-client-ca
@@ -117,6 +135,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: kcp-client-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   ca:
     secretName: kcp-client-ca
@@ -125,6 +146,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-front-proxy-kcp-client-cert
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   secretName: kcp-front-proxy-kcp-client-cert
   duration: 8760h0m0s # 365d
@@ -146,6 +170,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: client-cert-for-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   secretName: client-cert-for-kubeconfig
   duration: 8760h0m0s # 365d
@@ -165,6 +192,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-service-account-signing-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   isCA: true
   commonName: kcp-service-account-signing-ca
@@ -180,6 +210,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: kcp-service-account-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   ca:
     secretName: kcp-service-account-signing-ca
@@ -188,6 +221,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-service-account-cert
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   commonName: kcp-service-account-cert
   secretName: kcp-service-account-cert
@@ -200,6 +236,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-front-proxy-virtual-workspaces-client-cert
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   secretName: kcp-front-proxy-virtual-workspaces-client-cert
   duration: 8760h0m0s # 365d
@@ -221,6 +260,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kcp-front-proxy
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
   {{- with .Values.kcpFrontProxy.service.annotations }}
   annotations: 
     {{- toYaml . | nindent 4 }}
@@ -233,12 +275,16 @@ spec:
       port: 8443
       targetPort: 8443
   selector:
-    app: kcp-front-proxy
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kcp-front-proxy-config
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 data:
   path-mapping.yaml: |
     - path: /
@@ -252,18 +298,21 @@ kind: Deployment
 metadata:
   name: kcp-front-proxy
   labels:
-    app: kcp-front-proxy
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kcp-front-proxy
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "front-proxy"
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: kcp-front-proxy
+        {{- include "common.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "front-proxy"
     spec:
       securityContext:
         seccompProfile:

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -3,6 +3,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   isCA: true
   commonName: kcp-ca
@@ -18,6 +21,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-requestheader-client-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   isCA: true
   commonName: kcp-requestheader-client-ca
@@ -33,6 +39,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-server-client-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   isCA: true
   commonName: kcp-server-client-ca
@@ -48,6 +57,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: kcp-server-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   ca:
     secretName: kcp-ca
@@ -56,6 +68,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: kcp-server-client-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   ca:
     secretName: kcp-server-client-ca
@@ -64,6 +79,9 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: kcp-requestheader-client-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   ca:
     secretName: kcp-requestheader-client-ca
@@ -72,6 +90,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   secretName: kcp-cert
   duration: 8760h0m0s # 365d
@@ -95,6 +116,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-virtual-workspaces
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   secretName: kcp-virtual-workspaces-cert
   duration: 8760h0m0s # 365d
@@ -119,6 +143,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kcp-etcd-client
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   secretName: kcp-etcd-client
   duration: 8760h0m0s # 365d
@@ -136,6 +163,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: logical-cluster-admin-client-cert-for-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   secretName: logical-cluster-admin-client-cert-for-kubeconfig
   duration: 8760h0m0s # 365d
@@ -155,6 +185,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: external-logical-cluster-admin-client-cert-for-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   secretName: external-logical-cluster-admin-client-cert-for-kubeconfig
   duration: 8760h0m0s # 365d
@@ -174,6 +207,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: kcp
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   accessModes:
   - ReadWriteOnce
@@ -187,6 +223,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: kcp-audit-logs
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   accessModes:
   - ReadWriteOnce
@@ -201,7 +240,8 @@ kind: Service
 metadata:
   name: kcp
   labels:
-    app: kcp
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   ports:
     - protocol: TCP
@@ -213,14 +253,16 @@ spec:
       port: 6444
       targetPort: 6444
   selector:
-    app: kcp
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: kcp-internal
   labels:
-    app: kcp
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   ports:
     - protocol: TCP
@@ -232,25 +274,29 @@ spec:
       port: 444
       targetPort: 6444
   selector:
-    app: kcp
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kcp
   labels:
-    app: kcp
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kcp
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "server"
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: kcp
+        {{- include "common.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "server"
     spec:
       securityContext:
         # this matches the group id as set in the kcp Dockerfile.

--- a/charts/kcp/templates/lets-encrypt-ca.yaml
+++ b/charts/kcp/templates/lets-encrypt-ca.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kcp-root-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
 data:
   root-ca.pem: |
     -----BEGIN CERTIFICATE-----

--- a/charts/kcp/templates/logical-cluster-admin-kubeconfig.yaml
+++ b/charts/kcp/templates/logical-cluster-admin-kubeconfig.yaml
@@ -23,4 +23,6 @@ stringData:
 kind: Secret
 metadata:
   name: logical-cluster-admin-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/kcp/templates/rolebinding-edit-access.yaml
+++ b/charts/kcp/templates/rolebinding-edit-access.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kcp-dev-edit-access
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This PR updates the labels used for all resources created by this Helm chart to use [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) instead of the `app` label currently used on only a few resources (Deployments and StatefulSets) mostly.

Since this updates the label selectors, deleting the Deployments and StatefulSets before upgrading is required. Since we discussed that breaking changes are okay right now, I deemed that acceptable.