### PR TITLE
Move security context to `values.yaml`

### DIFF
--- a/charts/kcp/templates/kcp-front-proxy.yaml
+++ b/charts/kcp/templates/kcp-front-proxy.yaml
@@ -265,9 +265,10 @@ spec:
       labels:
         app: kcp-front-proxy
     spec:
+      {{- with .Values.kcpFrontProxy.securityContext }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.kcpFrontProxy.hostAliases.enabled }}
       hostAliases:
         {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 6 }}

--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -252,11 +252,10 @@ spec:
       labels:
         app: kcp
     spec:
+      {{- with .Values.kcp.securityContext }}
       securityContext:
-        # this matches the group id as set in the kcp Dockerfile.
-        fsGroup: 65532
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.kcp.hostAliases.enabled }}
       hostAliases:
         {{- toYaml .Values.kcp.hostAliases.values | nindent 6 }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -49,6 +49,11 @@ kcp:
     enabled: false
   homeWorkspaces:
     enabled: false
+  securityContext:
+  # this matches the group id as set in the kcp Dockerfile.
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
 kcpFrontProxy:
   image: ghcr.io/kcp-dev/kcp
   tag: latest
@@ -88,6 +93,9 @@ kcpFrontProxy:
       memory: 1Gi
   hostAliases:
     enabled: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
 oidc:
   enabled: false
 audit:


### PR DESCRIPTION
Since the `securityContext` I added to make the Helm chart work on vanilla Kubernetes is creating issues on OpenShift, this moves configuration for it to `values.yaml` file so we ship a sane default for (vanilla) Kubernetes users while allowing others to override settings as they require.

This is related to #52.