### PR TITLE
Improve kind scripting

### DIFF
--- a/hack/generate-admin-kubeconfig.sh
+++ b/hack/generate-admin-kubeconfig.sh
@@ -1,29 +1,30 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
 
-hostname=$(cat ./hack/kind-values.yaml | grep externalHostname | cut -d" " -f2- | tr -d '"')
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+hostname="$(yq '.externalHostname' hack/kind-values.yaml)"
 
 cat << EOF > kcp.kubeconfig
 apiVersion: v1
-clusters:
-- cluster:
-    insecure-skip-tls-verify: true
-    server: https://${hostname}:6443/clusters/root
-  name: kind-kcp
-contexts:
-- context:
-    cluster: kind-kcp
-    user: kind-kcp
-  name: kind-kcp
-current-context: kind-kcp
 kind: Config
-preferences: {}
+clusters:
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: "https://$hostname:6443/clusters/root"
+    name: kind-kcp
+contexts:
+  - context:
+      cluster: kind-kcp
+      user: kind-kcp
+    name: kind-kcp
+current-context: kind-kcp
 users:
-- name: kind-kcp
-  user:
-    token: admin-token
+  - name: kind-kcp
+    user:
+      token: admin-token
 EOF
-
 
 echo "Kubeconfig file created at kcp.kubeconfig"
 echo ""

--- a/hack/kind-values.yaml
+++ b/hack/kind-values.yaml
@@ -2,12 +2,14 @@ externalHostname: "kcp.dev.local"
 etcd:
   enabled: false
 kcp:
+  # tag is set via --set flag to make it more dynamic for testing purposes
   volumeClassName: "standard"
   tokenAuth:
     enabled: true
   etcd:
     serverAddress: embedded
 kcpFrontProxy:
+  # tag is set via --set flag to make it more dynamic for testing purposes
   openshiftRoute:
     enabled: false
   ingress:
@@ -15,6 +17,3 @@ kcpFrontProxy:
     annotations:
       kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-  certificate:
-    issuerSpec:
-      selfSigned: {}

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -1,19 +1,17 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  EphemeralContainers: true
 kubeadmConfigPatches:
-- |
-  apiVersion: kubeadm.k8s.io/v1beta2
-  kind: ClusterConfiguration
-  metadata:
-    name: config
-  apiServer:
-    extraArgs:
-      "enable-admission-plugins": NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "enable-admission-plugins": NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota
 nodes:
   - role: control-plane
-    image: kindest/node:v1.26.6
+    image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration


### PR DESCRIPTION
This PR updates the `kind-setup` script:

* re-indented the code
* Use yq instead of cat|grep|cut|tr.
* kind is only installed locally (no sudo required) and only if it's not existing (regardless of where the binary exists).
* The kind cluster was updated to 1.27.3 (with this release, the EphemeralContainer feature gate became GA and was removed).
* The script now provides a `kcp.kubeconfig` and a `kcp-kind.kubeconfig`.
* `kubectl rollout status` is used instead of a custom wait loop that greps for numbers.
* cert-manager was updated from 1.9.1 to 1.13.0.
* At the moment, kcp does not produce `latest` images anymore, so the script now allows to set `KCP_TAG` to override the version and actually install something recent (e.g. `KCP_TAG=bb5ce8f3 hack/kind-setup.sh`).
* The `/etc/hosts` adjustments now take the actual root domain into account, instead of hardcoding `kcp.dev.local`.

This might not work properly without #56, as I used #56 to test this PR.