### PR TITLE
Add presubmit job to prevent chart from going bad

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,19 @@
+presubmits:
+  - name: pull-helm-charts-render
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/helm-charts"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+          command:
+            - helm
+          args:
+            - template
+            - --debug
+            - kcp
+            - charts/kcp/
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 250m

--- a/charts/kcp/templates/rolebinding-edit-access.yaml
+++ b/charts/kcp/templates/rolebinding-edit-access.yaml
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   name: kcp-dev-edit-access
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+    {{- include "common.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
My previous PR accidentally broke the chart because after rebasing I did not test it again.

This PR adds a presubmit job to prevent this from happening again.