### PR TITLE
Update service selector for etcd headless service

### DIFF
--- a/charts/kcp/templates/etcd.yaml
+++ b/charts/kcp/templates/etcd.yaml
@@ -138,7 +138,8 @@ spec:
     - port: 2380
       name: peer
   selector:
-    app: etcd
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
In #53 I forgot to update the label selector in the `Service` object for etcd. This fixes that regression.