### PR TITLE
Use kcp-client-issuer for external-admin-kubeconfig certificate

### DIFF
--- a/charts/kcp/templates/kcp.yaml
+++ b/charts/kcp/templates/kcp.yaml
@@ -201,7 +201,7 @@ spec:
   usages:
     - client auth
   issuerRef:
-    name: kcp-server-client-issuer
+    name: kcp-client-issuer
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
After PKI cleanups done in #56, we are starting to see the effects of incorrect CAs used for certain `Certificates`. This is one of the cases:

`external-logical-cluster-admin-client-cert-for-kubeconfig` is used in the `external-logical-cluster-admin-kubeconfig` Secret as client certificate to access the kcp-front-proxy: https://github.com/kcp-dev/helm-charts/blob/f808f2b7c88736142137caea36ffd83ebd2e6197/charts/kcp/templates/external-logical-cluster-admin-kubeconfig.yaml#L16

 But since the certificate is signed by `kcp-server-client-ca`, the front proxy will reject requests with this certificate, as it's using the `kcp-client-ca` to validate incoming client certificates:
 
 https://github.com/kcp-dev/helm-charts/blob/f808f2b7c88736142137caea36ffd83ebd2e6197/charts/kcp/templates/kcp-front-proxy.yaml#L334
 
 This PR updates the `issuerRef` on the `Certificate` in question so that it gets signed by the CA used by kcp-front-proxy, not the CA used by kcp(-server).