### PR TITLE
Update to helm/chart-releaser-action@v1.6.0 and skip releasing for existing versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This bumps the `helm/chart-releaser-action` to the latest available version ([v1.6.0](https://github.com/helm/chart-releaser-action)) and also enables `skip_existing`, an option that will prevent our GitHub Actions to fail on every commit we merge into `main` that doesn't bump the chart version.