### PR TITLE
Fix bug in front-proxy-certificates.yaml

### DIFF
--- a/charts/kcp/templates/front-proxy-certificates.yaml
+++ b/charts/kcp/templates/front-proxy-certificates.yaml
@@ -67,6 +67,7 @@ spec:
     - client auth
   issuerRef:
     name: kcp-server-client-issuer
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:


### PR DESCRIPTION
Missing `---` separator