### PR TITLE
✨ Add `kcp.batteries` to `values.yaml` and set them on kcp deployment

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.4.0
+version: 0.4.1
 appVersion: "0.21.0"
 
 # optional metadata

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -178,6 +178,9 @@ spec:
             {{- if .Values.kcp.profiling.enabled }}
             - --profiler-address=0.0.0.0:{{- .Values.kcp.profiling.port -}}
             {{- end }}
+            {{- with .Values.kcp.batteries }}
+            - --batteries-included={{ join "," . }}
+            {{- end }}
             {{- range .Values.kcp.extraFlags }}
             {{ . }}
             {{- end }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -21,6 +21,9 @@ kcp:
   v: "3"
   logicalClusterAdminFlag: true
   externalLogicalClusterAdminFlag: true
+  # enabled "batteries" (see kcp start --help for available batteries).
+  batteries:
+    - workspace-types
   resources:
     requests:
       memory: 512Mi


### PR DESCRIPTION
Fixes #69.

This adds `kcp.batteries` to the chart's `values.yaml` and sets the `--batteries-included` flag on the `kcp` Deployment.

This will become useful with a future release of kcp that includes https://github.com/kcp-dev/kcp/pull/3041 (the `admin` battery) so we can disable writing `admin.kubeconfig`.