### PR TITLE
⚠️ correctly check if etcd StatefulSet is enabled to set `--etcd-servers`

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.4.1
+version: 0.4.2
 appVersion: "0.21.0"
 
 # optional metadata

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -121,7 +121,7 @@ spec:
           args:
             {{- if .Values.kcp.etcd.serverAddress }}
             - --etcd-servers={{ .Values.kcp.etcd.serverAddress }}
-            {{- else if .Values.kcp.etcd.enabled }}
+            {{- else if .Values.etcd.enabled }}
             - --etcd-servers=https://{{ include "etcd.fullname" . }}:2379
             {{- end }}
             {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}


### PR DESCRIPTION
All the time back in #65, I made a mistake in the if condition guarding the `--etcd-servers` flag. `.kcp.etcd.enabled` doesn't exist, `etcd.enabled` does. This fixes that oversight. Because the flag wasn't set, **kcp was using the embedded etcd.**

⚠️ This is a breaking change because it will change the kcp server from using the embedded etcd as datastore to the external etcd StatefulSet that is part of the Helm chart. But this will seemingly wipe all data from your kcp instance.

If you want to retain data, you'll need to set `.kcp.etcd.serverAddress="embedded"` before upgrading.