### PR TITLE
🐛 fix `kcp.extraFlags` being applied incorrectly

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.4.2
+version: 0.4.3
 appVersion: "0.21.0"
 
 # optional metadata

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -182,7 +182,7 @@ spec:
             - --batteries-included={{ join "," . }}
             {{- end }}
             {{- range .Values.kcp.extraFlags }}
-            {{ . }}
+            - {{ . }}
             {{- end }}
           env:
             - name: EXTERNAL_HOSTNAME


### PR DESCRIPTION
I tried out `kcp.extraFlags` and figured out it wasn't working. This fixes it and processes the list correctly.