### PR TITLE
add kcpFrontProxy.extraFlags to pass additional flags to kcp-front-proxy Deployment

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.4.3
+version: 0.4.4
 appVersion: "0.21.0"
 
 # optional metadata

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -85,6 +85,9 @@ spec:
             {{- if .Values.kcp.tokenAuth.enabled }}
             - --token-auth-file=/etc/kcp/token-auth/{{ .Values.kcp.tokenAuth.fileName }}
             {{- end }}
+            {{- range .Values.kcpFrontProxy.extraFlags }}
+            - {{ . }}
+            {{- end }}
           ports:
             - containerPort: 8443
           livenessProbe:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -123,16 +123,17 @@ kcpFrontProxy:
   # access to the CA that signed the VW's serving cert. Unless your
   # VWs all use the kcp-server-issuer, you must mount all additional
   # certificates yourself.
-  extraVolumes:
+  extraVolumes: []
   # - name: example-vw-serving-cert
   #   secret:
   #     secretName: example-vw-serving-cert
   #     items:
   #       - key: ca.crt
   #         path: ca.crt
-  extraVolumeMounts:
+  extraVolumeMounts: []
   # - name: example-vw-serving-cert
   #   mountPath: /etc/example-vw-serving-cert
+  extraFlags: []
 oidc:
   enabled: false
   caSecretName: ""


### PR DESCRIPTION
This adds `kcpFrontProxy.extraFlags` which mirrors `kcp.extraFlags`, so that additional flags can be passed (e.g. for using https://github.com/kcp-dev/kcp/pull/3013).