### PR TITLE
:sparkles:  Add secret template for main certificates

### DIFF
--- a/charts/kcp/templates/server-ca.yaml
+++ b/charts/kcp/templates/server-ca.yaml
@@ -16,7 +16,17 @@ spec:
     name: {{ include "kcp.fullname" . }}-pki
     kind: Issuer
     group: cert-manager.io
-
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -36,7 +46,17 @@ spec:
     name: {{ include "kcp.fullname" . }}-pki
     kind: Issuer
     group: cert-manager.io
-
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -56,7 +76,17 @@ spec:
     name: {{ include "kcp.fullname" . }}-pki
     kind: Issuer
     group: cert-manager.io
-
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -76,4 +106,14 @@ spec:
     name: {{ include "kcp.fullname" . }}-pki
     kind: Issuer
     group: cert-manager.io
-
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -170,6 +170,10 @@ certificates:
   # add additional dns names that should be embedded into the kcp server certificate.
   dnsNames:
   - localhost
+  secretTemplate:
+    enabled: false
+    annotations: {}
+    labels: {}
 letsEncrypt:
   enabled: false
   staging:


### PR DESCRIPTION
Adds labels and annotations template to main certificates.
This helps when deploying other components in different namespaces outside `kcp` and you need certificates to establish trust.

Example:
```
certificates:
  secretTemplate:
    enabled: true
    annotations:
      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cluster-proxy"  # Control destination namespaces
      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true" # Auto create reflection for matching namespaces
      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "cluster-proxy" # Control auto-reflection namespaces
```