### PR TITLE
POC multi-stage certs split for shards

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,14 @@ user `system:authenticated` access to a workspace.
 
 The chart will create a full PKI system, with root CA, intermediate CAs and more. The diagram below
 shows the default configuration, however the issuer for the `kcp-front-proxy` certificate can be
-configured and use, for example, Let's Encrypt.
+configured and used, for example, Let's Encrypt.
+
+```
+.Values.certificates.createPKI - create CA, Issues
+.Values.certificates.createCA - create CA's for etcd, front-proxy, server, requestheader, client, service-account
+.Values.certificates.enabled - creates certificates for named components
+```
+
 
 ```mermaid
 graph TB

--- a/charts/kcp/templates/_helpers.tpl
+++ b/charts/kcp/templates/_helpers.tpl
@@ -19,6 +19,16 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "certificates.kcp" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "kcp.version" -}}
 {{- if .Values.kcp.tag -}}
 {{- .Values.kcp.tag -}}
@@ -32,11 +42,31 @@ v{{- .Chart.AppVersion -}}
 {{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "certificates.frontproxy" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "frontproxy.version" -}}
 {{- if .Values.kcpFrontProxy.tag -}}
 {{- .Values.kcpFrontProxy.tag -}}
 {{- else -}}
 v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.etcd" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/kcp/templates/etcd-ca.yaml
+++ b/charts/kcp/templates/etcd-ca.yaml
@@ -1,40 +1,62 @@
-{{- if .Values.etcd.enabled -}}
+{{- if .Values.certificates.etcd.pki -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "etcd.fullname" . }}-client-ca
+  name: {{ include "certificates.etcd" . }}-client-ca
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "etcd"
 spec:
   isCA: true
   duration: 87600h # 3650d = 10y
-  commonName: {{ include "etcd.fullname" . }}-client-ca
-  secretName: {{ include "etcd.fullname" . }}-client-ca
+  commonName: {{ include "certificates.etcd" . }}-client-ca
+  secretName: {{ include "certificates.etcd" . }}-client-ca
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
     name: {{ include "kcp.fullname" . }}-pki
     kind: Issuer
     group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "etcd.fullname" . }}-peer-ca
+  name: {{ include "certificates.etcd" . }}-peer-ca
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "etcd"
 spec:
   isCA: true
   duration: 87600h # 3650d = 10y
-  commonName: {{ include "etcd.fullname" . }}-peer-ca
-  secretName: {{ include "etcd.fullname" . }}-peer-ca
+  commonName: {{ include "certificates.etcd" . }}-peer-ca
+  secretName: {{ include "certificates.etcd" . }}-peer-ca
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
     name: {{ include "kcp.fullname" . }}-pki
     kind: Issuer
     group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kcp/templates/etcd-certificates.yaml
+++ b/charts/kcp/templates/etcd-certificates.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.etcd.enabled -}}
+
+{{- if .Values.certificates.etcd.certs -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -30,8 +31,18 @@ spec:
   ipAddresses:
     - 0.0.0.0
   issuerRef:
-    name: {{ include "etcd.fullname" . }}-client-issuer
-
+    name: {{ include "certificates.etcd" . }}-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -63,5 +74,16 @@ spec:
   ipAddresses:
     - 0.0.0.0
   issuerRef:
-    name: {{ include "etcd.fullname" . }}-peer-issuer
+    name: {{ include "certificates.etcd" . }}-peer-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kcp/templates/etcd-issuers.yaml
+++ b/charts/kcp/templates/etcd-issuers.yaml
@@ -1,24 +1,24 @@
-{{- if .Values.etcd.enabled -}}
+{{- if .Values.certificates.etcd.pki -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "etcd.fullname" . }}-client-issuer
+  name: {{ include "certificates.etcd" . }}-client-issuer
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "etcd"
 spec:
   ca:
-    secretName: {{ include "etcd.fullname" . }}-client-ca
+    secretName: {{ include "certificates.etcd" . }}-client-ca
 
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "etcd.fullname" . }}-peer-issuer
+  name: {{ include "certificates.etcd" . }}-peer-issuer
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "etcd"
 spec:
   ca:
-    secretName: {{ include "etcd.fullname" . }}-peer-ca
+    secretName: {{ include "certificates.etcd" . }}-peer-ca
 {{- end }}

--- a/charts/kcp/templates/etcd-statefulset.yaml
+++ b/charts/kcp/templates/etcd-statefulset.yaml
@@ -93,15 +93,15 @@ spec:
         - name: peer-cert
           secret:
             secretName: {{ include "etcd.fullname" . }}-peer-cert
-        - name: peer-ca
-          secret:
-            secretName: {{ include "etcd.fullname" . }}-peer-ca
         - name: server-cert
           secret:
             secretName: {{ include "etcd.fullname" . }}-cert
+        - name: peer-ca
+          secret:
+            secretName: {{ include "certificates.etcd" . }}-peer-ca
         - name: client-ca
           secret:
-            secretName: {{ include "etcd.fullname" . }}-client-ca
+            secretName: {{ include "certificates.etcd" . }}-client-ca
   volumeClaimTemplates:
     - metadata:
         name: etcd-data

--- a/charts/kcp/templates/front-proxy-ca.yaml
+++ b/charts/kcp/templates/front-proxy-ca.yaml
@@ -1,18 +1,31 @@
+{{- if .Values.certificates.frontproxy.pki -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "frontproxy.fullname" . }}-client-ca
+  name: {{ include "certificates.frontproxy" . }}-client-ca
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "front-proxy"
 spec:
   isCA: true
   duration: 87600h # 3650d = 10y
-  commonName: {{ include "frontproxy.fullname" . }}-client-ca
-  secretName: {{ include "frontproxy.fullname" . }}-client-ca
+  commonName: {{ include "certificates.frontproxy" . }}-client-ca
+  secretName: {{ include "certificates.frontproxy" . }}-client-ca
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
     name: {{ include "kcp.fullname" . }}-pki
     kind: Issuer
     group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kcp/templates/front-proxy-certificates.yaml
+++ b/charts/kcp/templates/front-proxy-certificates.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.certificates.frontproxy.certs -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -23,10 +24,20 @@ spec:
     {{- if .Values.kcpFrontProxy.certificateIssuer }}
     {{ .Values.kcpFrontProxy.certificateIssuer | toYaml | nindent 4 }}
     {{- else }}
-    name: {{ include "kcp.fullname" . }}-server-issuer
+    name: {{ include "certificates.kcp" . }}-server-issuer
     kind: Issuer
     {{- end }}
-
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -50,8 +61,18 @@ spec:
   dnsNames:
     - "{{ include "frontproxy.fullname" . }}"
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-requestheader-client-issuer
-
+    name: {{ include "certificates.kcp" . }}-requestheader-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -73,10 +94,20 @@ spec:
   usages:
     - client auth
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-client-issuer
+    name: {{ include "certificates.kcp" . }}-client-issuer
     kind: Issuer
     group: cert-manager.io
-
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -100,6 +131,18 @@ spec:
   dnsNames:
     - "{{ include "frontproxy.fullname" . }}"
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-requestheader-client-issuer
+    name: {{ include "certificates.kcp" . }}-requestheader-client-issuer
     kind: Issuer
     group: cert-manager.io
+    {{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kcp/templates/front-proxy-configmap.yaml
+++ b/charts/kcp/templates/front-proxy-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kcpFrontProxy.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,3 +16,4 @@ data:
     {{- with .Values.kcpFrontProxy.additionalPathMappings }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
+{{- end }}

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kcpFrontProxy.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -155,7 +156,7 @@ spec:
             secretName: {{ include "frontproxy.fullname" . }}-cert
         - name: kcp-front-proxy-client-ca
           secret:
-            secretName: {{ include "frontproxy.fullname" . }}-client-ca
+            secretName: {{ include "certificates.frontproxy" . }}-client-ca
         - name: kcp-service-account-cert
           secret:
             secretName: {{ include "kcp.fullname" . }}-service-account-cert
@@ -177,10 +178,11 @@ spec:
         # these volumes are necessary for the path-mapping.yaml
         - name: kcp-ca
           secret:
-            secretName: {{ include "kcp.fullname" . }}-ca
+            secretName: {{ include "certificates.kcp" . }}-ca
         - name: kcp-requestheader-client-cert
           secret:
             secretName: {{ include "frontproxy.fullname" . }}-requestheader-cert
 {{- with .Values.kcpFrontProxy.extraVolumes }}
 {{ . | toYaml | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/kcp/templates/front-proxy-ingress.yaml
+++ b/charts/kcp/templates/front-proxy-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kcpFrontProxy.enabled }}
 {{- if .Values.kcpFrontProxy.openshiftRoute.enabled }}
 ---
 apiVersion: route.openshift.io/v1
@@ -88,4 +89,5 @@ spec:
           port: 8443
   hostnames:
     - {{ .Values.externalHostname }}
+{{- end }}
 {{- end }}

--- a/charts/kcp/templates/front-proxy-issuers.yaml
+++ b/charts/kcp/templates/front-proxy-issuers.yaml
@@ -1,10 +1,12 @@
+{{- if.Values.certificates.frontproxy.pki  -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "frontproxy.fullname" . }}-client-issuer
+  name: {{ include "certificates.frontproxy" . }}-client-issuer
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "front-proxy"
 spec:
   ca:
-    secretName: {{ include "frontproxy.fullname" . }}-client-ca
+    secretName: {{ include "certificates.frontproxy" . }}-client-ca
+{{- end }}

--- a/charts/kcp/templates/front-proxy-kubeconfig.yaml
+++ b/charts/kcp/templates/front-proxy-kubeconfig.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kcpFrontProxy.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -27,3 +28,4 @@ stringData:
         user:
           client-certificate: /etc/kcp-front-proxy/kubeconfig-client-cert/tls.crt
           client-key: /etc/kcp-front-proxy/kubeconfig-client-cert/tls.key
+{{- end }}

--- a/charts/kcp/templates/pki-issuers.yaml
+++ b/charts/kcp/templates/pki-issuers.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.certificates.kcp.pki -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -40,3 +41,4 @@ metadata:
 spec:
   ca:
     secretName: {{ include "kcp.fullname" . }}-pki-ca
+{{- end }}

--- a/charts/kcp/templates/server-ca.yaml
+++ b/charts/kcp/templates/server-ca.yaml
@@ -1,79 +1,122 @@
+{{- if .Values.certificates.kcp.pki -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "kcp.fullname" . }}-ca
+  name: {{ include "certificates.kcp" . }}-ca
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "server"
 spec:
   isCA: true
   duration: 87600h # 3650d = 10y
-  commonName: {{ include "kcp.fullname" . }}-ca
-  secretName: {{ include "kcp.fullname" . }}-ca
+  commonName: {{ include "certificates.kcp" . }}-ca
+  secretName: {{ include "certificates.kcp" . }}-ca
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-pki
+    name: {{ include "certificates.kcp" . }}-pki
     kind: Issuer
     group: cert-manager.io
-
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "kcp.fullname" . }}-requestheader-client-ca
+  name: {{ include "certificates.kcp" . }}-requestheader-client-ca
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "server"
 spec:
   isCA: true
   duration: 87600h # 3650d = 10y
-  commonName: {{ include "kcp.fullname" . }}-requestheader-client-ca
-  secretName: {{ include "kcp.fullname" . }}-requestheader-client-ca
+  commonName: {{ include "certificates.kcp" . }}-requestheader-client-ca
+  secretName: {{ include "certificates.kcp" . }}-requestheader-client-ca
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-pki
+    name: {{ include "certificates.kcp" . }}-pki
     kind: Issuer
     group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "kcp.fullname" . }}-client-ca
+  name: {{ include "certificates.kcp" . }}-client-ca
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "server"
 spec:
   isCA: true
   duration: 87600h # 3650d = 10y
-  commonName: {{ include "kcp.fullname" . }}-client-ca
-  secretName: {{ include "kcp.fullname" . }}-client-ca
+  commonName: {{ include "certificates.kcp" . }}-client-ca
+  secretName: {{ include "certificates.kcp" . }}-client-ca
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-pki
+    name: {{ include "certificates.kcp" . }}-pki
     kind: Issuer
     group: cert-manager.io
-
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "kcp.fullname" . }}-service-account-ca
+  name: {{ include "certificates.kcp" . }}-service-account-ca
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "front-proxy"
 spec:
   isCA: true
   duration: 87600h # 3650d = 10y
-  commonName: {{ include "kcp.fullname" . }}-service-account-ca
-  secretName: {{ include "kcp.fullname" . }}-service-account-ca
+  commonName: {{ include "certificates.kcp" . }}-service-account-ca
+  secretName: {{ include "certificates.kcp" . }}-service-account-ca
   privateKey:
     {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-pki
+    name: {{ include "certificates.kcp" . }}-pki
     kind: Issuer
     group: cert-manager.io
-
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kcp/templates/server-certificates.yaml
+++ b/charts/kcp/templates/server-certificates.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.certificates.kcp.certs -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -23,8 +24,18 @@ spec:
     - {{ . }}
     {{- end }}
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-server-issuer
-
+    name: {{ include "certificates.kcp" . }}-server-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -50,9 +61,18 @@ spec:
   - {{ . }}
   {{- end }}
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-server-issuer
-{{- if .Values.etcd.enabled }}
-
+    name: {{ include "certificates.kcp" . }}-server-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -74,8 +94,18 @@ spec:
     {{- if .Values.kcp.etcd.clientCertificate.issuer }}
     name: {{ .Values.kcp.etcd.clientCertificate.issuer }}
     {{- else }}
-    name: {{ include "etcd.fullname" . }}-client-issuer
+    name: {{ include "certificates.etcd" . }}-client-issuer
     {{- end }}
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
 {{- end }}
 
 ---
@@ -99,8 +129,18 @@ spec:
   usages:
     - client auth
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-client-issuer
-
+    name: {{ include "certificates.kcp" . }}-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -122,8 +162,18 @@ spec:
   usages:
     - client auth
   issuerRef:
-    name: {{ include "frontproxy.fullname" . }}-client-issuer
-
+    name: {{ include "certificates.frontproxy" . }}-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -138,6 +188,18 @@ spec:
   commonName: {{ include "kcp.fullname" . }}-service-account
   secretName: {{ include "kcp.fullname" . }}-service-account-cert
   issuerRef:
-    name: {{ include "kcp.fullname" . }}-service-account-issuer
+    name: {{ include "certificates.kcp" . }}-service-account-issuer
     kind: Issuer
     group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kcp.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -275,26 +276,26 @@ spec:
             secretName: {{ include "kcp.fullname" . }}-etcd-client-cert
         - name: etcd-client-ca
           secret:
-            secretName: {{ include "etcd.fullname" . }}-client-ca
+            secretName: {{ include "certificates.etcd" . }}-client-ca
         {{- end }}
         - name: kcp-ca
           secret:
-            secretName: {{ include "kcp.fullname" . }}-ca
+            secretName: {{ include "certificates.kcp" . }}-ca
         - name: kcp-cert
           secret:
             secretName: {{ include "kcp.fullname" .}}-cert
         - name: kcp-client-ca
           secret:
-            secretName: {{ include "kcp.fullname" . }}-client-ca
+            secretName: {{ include "certificates.kcp" . }}-client-ca
         - name: kcp-service-account-cert
           secret:
             secretName: {{ include "kcp.fullname" . }}-service-account-cert
         - name: kcp-service-account-ca
           secret:
-            secretName: {{ include "kcp.fullname" . }}-service-account-ca
+            secretName: {{ include "certificates.kcp" . }}-service-account-ca
         - name: kcp-requestheader-client-ca
           secret:
-            secretName: {{ include "kcp.fullname" . }}-requestheader-client-ca
+            secretName: {{ include "certificates.kcp" . }}-requestheader-client-ca
         {{- if .Values.oidc.enabled }}
         {{- if .Values.oidc.caSecretName }}
         - name: oidc-ca
@@ -350,3 +351,4 @@ stringData:
   {{ .Values.kcp.tokenAuth.fileName }}: |
     {{- .Values.kcp.tokenAuth.config | nindent 4 }}
 {{- end}}
+{{- end }}

--- a/charts/kcp/templates/server-issuers.yaml
+++ b/charts/kcp/templates/server-issuers.yaml
@@ -1,46 +1,48 @@
+{{- if .Values.certificates.kcp.pki -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "kcp.fullname" . }}-server-issuer
+  name: {{ include "certificates.kcp" . }}-server-issuer
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "server"
 spec:
   ca:
-    secretName: {{ include "kcp.fullname" . }}-ca
+    secretName: {{ include "certificates.kcp" . }}-ca
 
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "kcp.fullname" . }}-client-issuer
+  name: {{ include "certificates.kcp" . }}-client-issuer
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "server"
 spec:
   ca:
-    secretName: {{ include "kcp.fullname" . }}-client-ca
+    secretName: {{ include "certificates.kcp" . }}-client-ca
 
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "kcp.fullname" . }}-requestheader-client-issuer
+  name: {{ include "certificates.kcp" . }}-requestheader-client-issuer
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "server"
 spec:
   ca:
-    secretName: {{ include "kcp.fullname" . }}-requestheader-client-ca
+    secretName: {{ include "certificates.kcp" . }}-requestheader-client-ca
 
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "kcp.fullname" . }}-service-account-issuer
+  name: {{ include "certificates.kcp" . }}-service-account-issuer
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "front-proxy"
 spec:
   ca:
-    secretName: {{ include "kcp.fullname" . }}-service-account-ca
+    secretName: {{ include "certificates.kcp" . }}-service-account-ca
+{{- end }}

--- a/charts/kcp/templates/server-kubeconfigs.yaml
+++ b/charts/kcp/templates/server-kubeconfigs.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kcp.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -60,3 +61,4 @@ stringData:
         user:
           client-certificate: /etc/kcp/external-logical-cluster-admin/kubeconfig-client-cert/tls.crt
           client-key: /etc/kcp/external-logical-cluster-admin/kubeconfig-client-cert/tls.key
+{{- end }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -14,6 +14,7 @@ etcd:
   profiling:
     enabled: false
 kcp:
+  enabled: true
   image: ghcr.io/kcp-dev/kcp
   # set this to override the image tag used for kcp (determined by chart appVersion by default).
   tag: ""
@@ -63,6 +64,7 @@ kcp:
     seccompProfile:
       type: RuntimeDefault
 kcpFrontProxy:
+  enabled: true
   image: ghcr.io/kcp-dev/kcp
   # set this to override the image tag used for kcp-front-proxy (determined by chart appVersion by default).
   tag: ""
@@ -163,6 +165,19 @@ audit:
     maxBackup: "1"
     dir: /var/audit
 certificates:
+  kcp:
+    pki: true
+    certs: true
+  frontproxy:
+    pki: true
+    certs: true
+  etcd:
+    pki: true
+    certs: true
+  secretTemplate:
+    enabled: false
+    annotations: {}
+    labels: {}
   privateKeys:
     algorithm: RSA
     size: 2048

--- a/hack/kind-values-phase1.yaml
+++ b/hack/kind-values-phase1.yaml
@@ -1,0 +1,33 @@
+# Phase 1 creates PKI & CA infrastructure for all shards
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase1.yaml \
+#  --namespace kcp-root \
+#  --create-namespace \
+#  kcp ./charts/kcp
+#
+etcd:
+  enabled: false
+kcp:
+  enabled: false
+kcpFrontProxy:
+  enabled: false
+certificates:
+  name: certs
+  kcp:
+    pki: true
+    certs: false
+  frontproxy:
+    pki: true
+    certs: false
+  etcd:
+    pki: true
+    certs: false
+  secretTemplate:
+    enabled: true
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-alpha,kcp-beta"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-alpha,kcp-beta"

--- a/hack/kind-values-phase2-alpha.yaml
+++ b/hack/kind-values-phase2-alpha.yaml
@@ -1,0 +1,34 @@
+# Phase 2 creates creates the KCP and KCP Front Proxy, etc certs for shard 1
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase2.yaml \
+#  --namespace kcp-certs \
+#  --create-namespace \
+#  kcp ./charts/kcp
+#
+fullnameOverride: alpha
+etcd:
+  enabled: false
+kcp:
+  enabled: false
+kcpFrontProxy:
+  enabled: false
+certificates:
+  name: certs
+  kcp:
+    pki: false
+    certs: true
+  frontproxy:
+    pki: false
+    certs: true
+  etcd:
+    pki: false
+    certs: true
+  secretTemplate:
+    enabled: true
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-alpha"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-alpha"

--- a/hack/kind-values-phase2-beta.yaml
+++ b/hack/kind-values-phase2-beta.yaml
@@ -1,0 +1,34 @@
+# Phase 2 creates creates the KCP and KCP Front Proxy, etc certs for shard 1
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase2.yaml \
+#  --namespace kcp-certs \
+#  --create-namespace \
+#  kcp ./charts/kcp
+#
+fullnameOverride: beta
+etcd:
+  enabled: false
+kcp:
+  enabled: false
+kcpFrontProxy:
+  enabled: false
+certificates:
+  name: certs
+  kcp:
+    pki: false
+    certs: true
+  frontproxy:
+    pki: false
+    certs: true
+  etcd:
+    pki: false
+    certs: true
+  secretTemplate:
+    enabled: true
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-beta"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-beta"

--- a/hack/kind-values-phase3-alpha.yaml
+++ b/hack/kind-values-phase3-alpha.yaml
@@ -1,0 +1,39 @@
+# Phase 4 creates deployments for shard 1
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase3.yaml \
+#  --namespace kcp-alpha \
+#  --create-namespace \
+#  alpha ./charts/kcp
+#
+fullnameOverride: alpha
+externalHostname: "kcp-alpha.dev.local"
+etcd:
+  enabled: true
+kcp:
+  enabled: true
+  tag: main
+  batteries:
+    - workspace-types
+    - metrics-viewer
+kcpFrontProxy:
+  enabled: true
+certificates:
+  name: certs
+  kcp:
+    pki: false
+    certs: false
+  frontproxy:
+    pki: false
+    certs: false
+  etcd:
+    pki: false
+    certs: false
+  secretTemplate:
+    enabled: false
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-alpha"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-alpha"

--- a/hack/kind-values-phase3-beta.yaml
+++ b/hack/kind-values-phase3-beta.yaml
@@ -1,0 +1,39 @@
+# Phase 4 creates deployments for shard 1
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase3.yaml \
+#  --namespace kcp-alpha \
+#  --create-namespace \
+#  alpha ./charts/kcp
+#
+fullnameOverride: beta
+externalHostname: "kcp-beta.dev.local"
+etcd:
+  enabled: true
+kcp:
+  enabled: true
+  tag: main
+  batteries:
+    - workspace-types
+    - metrics-viewer
+kcpFrontProxy:
+  enabled: true
+certificates:
+  name: certs
+  kcp:
+    pki: false
+    certs: false
+  frontproxy:
+    pki: false
+    certs: false
+  etcd:
+    pki: false
+    certs: false
+  secretTemplate:
+    enabled: false
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-beta"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-beta"


### PR DESCRIPTION
This PR splits certificate management from main deployments:
* adds new name agnostic/shared certificates - pki
* adds ability to generate certs for specific deployments without deploying
* refactors charts to be able just to deploy with BYO certs
