### PR TITLE
✨ Add hack/ci/render-helm-charts.sh that improves validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.kubeconfig
+
+# output of hack/ci/validate-helm-resources.sh
+kcp-templated.yaml

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -5,15 +5,9 @@ presubmits:
     clone_uri: "https://github.com/kcp-dev/helm-charts"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.8-1
+        - image: ghcr.io/kcp-dev/infra/build:1.20.9-3
           command:
-            - helm
-          args:
-            - template
-            - --debug
-            - --set=externalHostname=ci.kcp.io
-            - kcp
-            - charts/kcp/
+            - hack/ci/render-helm-charts.sh
           resources:
             requests:
               memory: 64Mi

--- a/hack/ci/render-helm-charts.sh
+++ b/hack/ci/render-helm-charts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+if ! [ -x "$(command -v helm)" ]; then
+    echo "missing helm command in PATH"
+    exit 1
+fi
+
+if ! [ -x "$(command -v kubeconform)" ]; then
+    echo "missing kubeconform command in PATH"
+    exit 1
+fi
+
+helm template \
+  --debug \
+  --set=externalHostname=ci.kcp.io \
+  kcp charts/kcp/ | tee kcp-templated.yaml
+
+echo "---"
+
+# run kubeconform on template output to validate Kubernetes resources.
+# the external schema-location allows us to validate resources for
+# common CRDs (e.g. cert-manager resources).
+kubeconform \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+  -strict \
+  -summary \
+  kcp-templated.yaml


### PR DESCRIPTION
To further improve validation of PRs to this repository, I added [kubeconform](https://github.com/yannh/kubeconform) to our build image in https://github.com/kcp-dev/infra/pull/62.

This improves the `pull-helm-charts-render` Prow job by not just checking if Helm can render templates, but also if those rendered templates are valid Kubernetes resources.