### PR TITLE
add shard'ed deployment example

### DIFF
--- a/charts/cache/Chart.yaml
+++ b/charts/cache/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: kcp
+description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
+
+# version information
+version: 0.4.4
+appVersion: "0.21.0"
+
+# optional metadata
+type: application
+home: https://www.kcp.io/
+keywords:
+  - kcp
+  - kubernetes
+  - multitenancy
+  - controlplane
+sources:
+  - https://github.com/kcp-dev/helm-charts
+  - https://github.com/kcp-dev/kcp
+icon: https://raw.githubusercontent.com/kcp-dev/kcp/main/contrib/logo/blue-green.svg

--- a/charts/cache/LICENSE
+++ b/charts/cache/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/cache/README.md
+++ b/charts/cache/README.md
@@ -1,0 +1,10 @@
+# KCP Helm Chart - Cache server
+
+This Helm chart deploys cache server for KCP.
+
+* Cache server
+
+## Dependencies
+
+* cert-manager
+* cache server certificates deployed by [charts/certificates](../../charts/certificates)

--- a/charts/cache/templates/_helpers.tpl
+++ b/charts/cache/templates/_helpers.tpl
@@ -1,0 +1,104 @@
+{{- define "kcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.chartName" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.kcp" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kcp.version" -}}
+{{- if .Values.kcp.tag -}}
+{{- .Values.kcp.tag -}}
+{{- else -}}
+v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cache.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "frontproxy.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "certificates.cache" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.frontproxy" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "frontproxy.version" -}}
+{{- if .Values.kcpFrontProxy.tag -}}
+{{- .Values.kcpFrontProxy.tag -}}
+{{- else -}}
+v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.etcd" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "etcd.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "common.labels" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "kcp.chartName" . }}
+{{- end -}}
+
+{{- define "common.labels.selector" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/cache/templates/cache-deployment.yaml
+++ b/charts/cache/templates/cache-deployment.yaml
@@ -1,0 +1,122 @@
+{{- if .Values.cache.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cache.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "cache"
+spec:
+  ports:
+    - protocol: TCP
+      name: cache
+      port: 8012
+      targetPort: 8012
+  selector:
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "cache"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cache.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "cache"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "cache"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "common.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "cache"
+    spec:
+      {{- with .Values.cache.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.cache.hostAliases.enabled }}
+      hostAliases:
+        {{- toYaml .Values.cache.hostAliases.values | nindent 6 }}
+      {{- end }}
+      containers:
+        - name: cache
+          image: {{ .Values.cache.image }}:{{ .Values.cache.tag }}
+          imagePullPolicy: {{ .Values.cache.pullPolicy }}
+          ports:
+            - containerPort: 8012
+            {{- if .Values.cache.profiling.enabled }}
+            - containerPort: {{ .Values.cache.profiling.port }}
+              name: profiler
+            {{- end }}
+          command: ["/cache-server"]
+          args:
+            - --embedded-etcd-client-port=8010
+            - --embedded-etcd-peer-port=8011
+            - --secure-port=8012
+            - --synthetic-delay=0s
+            - --tls-private-key-file=/etc/cache/tls/server/tls.key
+            - --tls-cert-file=/etc/cache/tls/server/tls.crt
+            - --v={{ .Values.cache.v }}
+            {{- if .Values.cache.profiling.enabled }}
+            - --profiler-address=0.0.0.0:{{- .Values.cache.profiling.port -}}
+            {{- end }}
+            {{- range .Values.cache.extraFlags }}
+            - {{ . }}
+            {{- end }}
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.memory
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: livez
+              port: 8012
+              scheme: HTTPS
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          startupProbe:
+            httpGet:
+              path: readyz
+              port: 8012
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 36
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: readyz
+              port: 8012
+              scheme: HTTPS
+          {{- with .Values.cache.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: kcp-ca
+              mountPath: /etc/cache/tls/ca
+            - name: cache-cert
+              mountPath: /etc/cache/tls/server
+      volumes:
+        - name: kcp-ca
+          secret:
+            secretName: {{ include "certificates.kcp" . }}-ca
+        - name: cache-cert
+          secret:
+            secretName: {{ include "cache.fullname" .}}-cert
+{{- end }}

--- a/charts/cache/templates/cache-kubeconfigs.yaml
+++ b/charts/cache/templates/cache-kubeconfigs.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.cache.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cache.fullname" .}}-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "cache"
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority: /etc/kcp/tls/ca/tls.crt
+        server: "https://{{ include "cache.fullname" . }}{{ .Release.Namespace }}:8012"
+      name: cache
+    contexts:
+    - context:
+        cluster: cache
+        user: ""
+      name: cache
+    current-context: cache
+    kind: Config
+    preferences: {}
+    users: null
+{{- end }}

--- a/charts/cache/values.yaml
+++ b/charts/cache/values.yaml
@@ -1,0 +1,27 @@
+externalHostname: ""
+cache:
+  enabled: false
+  image: ghcr.io/kcp-dev/kcp
+  tag: "main"
+  pullPolicy: Always
+  v: "4"
+  service:
+    annotations: {}
+    # set this to LoadBalancer if you want to publish kcp-front-proxy
+    # directly instead of going via Route/Ingress/Gateway resources.
+    type: ClusterIP
+  profiling:
+    enabled: false
+    port: 6060
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      # cpu: 1
+      memory: 1Gi
+  hostAliases:
+    enabled: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/charts/certificates/Chart.yaml
+++ b/charts/certificates/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: kcp-certificates
+description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
+
+# version information
+version: 0.0.2
+appVersion: "0.21.0"
+
+# optional metadata
+type: application
+home: https://www.kcp.io/
+keywords:
+  - kcp
+  - kubernetes
+  - multitenancy
+  - controlplane
+sources:
+  - https://github.com/kcp-dev/helm-charts
+  - https://github.com/kcp-dev/kcp
+icon: https://raw.githubusercontent.com/kcp-dev/kcp/main/contrib/logo/blue-green.svg

--- a/charts/certificates/LICENSE
+++ b/charts/certificates/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/certificates/README.md
+++ b/charts/certificates/README.md
@@ -1,0 +1,12 @@
+# KCP Helm Chart - Certificates
+
+This Helm chart deploys all the certificates needed for KCP to run.
+
+* Cache certificates
+* Etcd certificates
+* KCP server certificates
+* FrontProxy certificates
+
+## Dependencies
+
+* cert-manager

--- a/charts/certificates/templates/_helpers.tpl
+++ b/charts/certificates/templates/_helpers.tpl
@@ -1,0 +1,104 @@
+{{- define "kcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.chartName" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.kcp" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kcp.version" -}}
+{{- if .Values.kcp.tag -}}
+{{- .Values.kcp.tag -}}
+{{- else -}}
+v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cache.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "frontproxy.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "certificates.cache" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.frontproxy" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "frontproxy.version" -}}
+{{- if .Values.kcpFrontProxy.tag -}}
+{{- .Values.kcpFrontProxy.tag -}}
+{{- else -}}
+v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.etcd" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "etcd.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "common.labels" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "kcp.chartName" . }}
+{{- end -}}
+
+{{- define "common.labels.selector" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/certificates/templates/cache-certificates.yaml
+++ b/charts/certificates/templates/cache-certificates.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.certificates.cache.certs -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "cache.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "cache"
+spec:
+  secretName: {{ include "cache.fullname" . }}-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  {{- with .Values.certificates.subject }}
+  subject:
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - server auth
+  dnsNames:
+    {{- range .Values.certificates.dnsNames }}
+    - {{ . }}
+    {{- end }}
+  issuerRef:
+    {{- if .Values.certificates.cache.certificateIssuer }}
+    {{ .Values.certificates.cache.certificateIssuer | toYaml | nindent 4 }}
+    {{- else }}
+    name: {{ include "certificates.cache" . }}-server-issuer
+    kind: Issuer
+    {{- end }}
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{- end }}

--- a/charts/certificates/templates/cache-issuers.yaml
+++ b/charts/certificates/templates/cache-issuers.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.certificates.cache.pki -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.cache" . }}-server-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  ca:
+    secretName: {{ include "certificates.kcp" . }}-ca
+{{- end -}}

--- a/charts/certificates/templates/etcd-ca.yaml
+++ b/charts/certificates/templates/etcd-ca.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.certificates.etcd.pki -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "certificates.etcd" . }}-client-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  isCA: true
+  duration: 87600h # 3650d = 10y
+  commonName: {{ include "certificates.etcd" . }}-client-ca
+  secretName: {{ include "certificates.etcd" . }}-client-ca
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-pki
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "certificates.etcd" . }}-peer-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  isCA: true
+  duration: 87600h # 3650d = 10y
+  commonName: {{ include "certificates.etcd" . }}-peer-ca
+  secretName: {{ include "certificates.etcd" . }}-peer-ca
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-pki
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/certificates/templates/etcd-certificates.yaml
+++ b/charts/certificates/templates/etcd-certificates.yaml
@@ -1,0 +1,89 @@
+
+{{- if .Values.certificates.etcd.certs -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "etcd.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  secretName: {{ include "etcd.fullname" . }}-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  {{- with .Values.certificates.subject }}
+  subject:
+    {{- toYaml . | nindent 4 }}
+  {{- end}}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - server auth
+    - client auth  # required because etcd uses this cert for calls to itself
+  dnsNames:
+    - {{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-0
+    - {{ include "etcd.fullname" . }}-1
+    - {{ include "etcd.fullname" . }}-2
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}
+  ipAddresses:
+    - 0.0.0.0
+  issuerRef:
+    name: {{ include "certificates.etcd" . }}-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "etcd.fullname" . }}-peer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  secretName: {{ include "etcd.fullname" . }}-peer-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  {{- with .Values.certificates.subject }}
+  subject:
+    {{- toYaml . | nindent 4 }}
+  {{- end}}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - {{ include "etcd.fullname" . }}-0
+    - {{ include "etcd.fullname" . }}-1
+    - {{ include "etcd.fullname" . }}-2
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}
+  ipAddresses:
+    - 0.0.0.0
+  issuerRef:
+    name: {{ include "certificates.etcd" . }}-peer-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/certificates/templates/etcd-issuers.yaml
+++ b/charts/certificates/templates/etcd-issuers.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.certificates.etcd.pki -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.etcd" . }}-client-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  ca:
+    secretName: {{ include "certificates.etcd" . }}-client-ca
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.etcd" . }}-peer-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  ca:
+    secretName: {{ include "certificates.etcd" . }}-peer-ca
+{{- end }}

--- a/charts/certificates/templates/front-proxy-ca.yaml
+++ b/charts/certificates/templates/front-proxy-ca.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.certificates.frontproxy.pki -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "certificates.frontproxy" . }}-client-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  isCA: true
+  duration: 87600h # 3650d = 10y
+  commonName: {{ include "certificates.frontproxy" . }}-client-ca
+  secretName: {{ include "certificates.frontproxy" . }}-client-ca
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-pki
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/certificates/templates/front-proxy-certificates.yaml
+++ b/charts/certificates/templates/front-proxy-certificates.yaml
@@ -1,0 +1,209 @@
+{{- if .Values.certificates.frontproxy.certs -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "frontproxy.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  secretName: {{ include "frontproxy.fullname" . }}-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  {{- with .Values.certificates.subject }}
+  subject:
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - server auth
+  dnsNames:
+    - "{{ .Values.externalHostname }}"
+  issuerRef:
+    {{- if .Values.certificates.certificateIssuer }}
+    {{ .Values.certificates.certificateIssuer | toYaml | nindent 4 }}
+    {{- else }}
+    name: {{ include "certificates.kcp" . }}-server-issuer
+    kind: Issuer
+    {{- end }}
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-requestheader
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  secretName: {{ include "frontproxy.fullname" . }}-requestheader-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  {{- with .Values.certificates.subject }}
+  subject:
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  dnsNames:
+    - "{{ include "frontproxy.fullname" . }}"
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-requestheader-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  secretName: {{ include "frontproxy.fullname" . }}-kubeconfig-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: {{ include "frontproxy.fullname" . }}
+  subject:
+    organizations:
+      - "system:masters"
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-client-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-service-account
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: {{ include "frontproxy.fullname" . }}-service-account
+  secretName: {{ include "frontproxy.fullname" . }}-service-account-cert
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-service-account-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-shard-client
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  secretName: {{ include "frontproxy.fullname" . }}-shard-client-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: {{ include "frontproxy.fullname" . }}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  subject:
+    organizations:
+      - "system:masters"
+  usages:
+    - client auth
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-vw-client
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  secretName: {{ include "frontproxy.fullname" . }}-vw-client-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  {{- with .Values.certificates.subject }}
+  subject:
+    {{- toYaml . | nindent 4 }}
+  {{ end}}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  dnsNames:
+    - "{{ include "frontproxy.fullname" . }}"
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-requestheader-client-issuer
+    kind: Issuer
+    group: cert-manager.io
+    {{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/certificates/templates/front-proxy-issuers.yaml
+++ b/charts/certificates/templates/front-proxy-issuers.yaml
@@ -1,0 +1,12 @@
+{{- if.Values.certificates.frontproxy.pki  -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.frontproxy" . }}-client-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  ca:
+    secretName: {{ include "certificates.frontproxy" . }}-client-ca
+{{- end }}

--- a/charts/certificates/templates/letsencrypt-clusterissuers.yaml
+++ b/charts/certificates/templates/letsencrypt-clusterissuers.yaml
@@ -1,0 +1,45 @@
+{{ if .Values.letsEncrypt.enabled }}
+{{ if .Values.letsEncrypt.staging.enabled }}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: kcp-letsencrypt-staging
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
+spec:
+  acme:
+    email: {{ .Values.letsEncrypt.staging.email }}}
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource that will be used to store the account's private key.
+      name: {{ include "kcp.fullname" . }}-le-issuer-account-key
+    # Add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+{{ end }}
+{{ if .Values.letsEncrypt.production.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: kcp-letsencrypt-prod
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
+spec:
+  acme:
+    email: {{ .Values.letsEncrypt.production.email }}
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource that will be used to store the account's private key.
+      name: {{ include "kcp.fullname" . }}-le-issuer-account-key
+    # Add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+{{ end }}
+{{ end }}

--- a/charts/certificates/templates/pki-issuers.yaml
+++ b/charts/certificates/templates/pki-issuers.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.certificates.kcp.pki -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.kcp" . }}-pki-bootstrap
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
+spec:
+  selfSigned: {}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "certificates.kcp" . }}-pki-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
+spec:
+  isCA: true
+  commonName: {{ include "certificates.kcp" . }}-pki-ca
+  secretName: {{ include "certificates.kcp" . }}-pki-ca
+  duration: 87600h # 3650d = 10y
+  renewBefore: 360h # 15d
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-pki-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.kcp" . }}-pki
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "pki"
+spec:
+  ca:
+    secretName: {{ include "certificates.kcp" . }}-pki-ca
+{{- end }}

--- a/charts/certificates/templates/server-ca.yaml
+++ b/charts/certificates/templates/server-ca.yaml
@@ -1,0 +1,122 @@
+{{- if .Values.certificates.kcp.pki -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "certificates.kcp" . }}-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  isCA: true
+  duration: 87600h # 3650d = 10y
+  commonName: {{ include "certificates.kcp" . }}-ca
+  secretName: {{ include "certificates.kcp" . }}-ca
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-pki
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "certificates.kcp" . }}-requestheader-client-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  isCA: true
+  duration: 87600h # 3650d = 10y
+  commonName: {{ include "certificates.kcp" . }}-requestheader-client-ca
+  secretName: {{ include "certificates.kcp" . }}-requestheader-client-ca
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-pki
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "certificates.kcp" . }}-client-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  isCA: true
+  duration: 87600h # 3650d = 10y
+  commonName: {{ include "certificates.kcp" . }}-client-ca
+  secretName: {{ include "certificates.kcp" . }}-client-ca
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-pki
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "certificates.kcp" . }}-service-account-ca
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  isCA: true
+  duration: 87600h # 3650d = 10y
+  commonName: {{ include "certificates.kcp" . }}-service-account-ca
+  secretName: {{ include "certificates.kcp" . }}-service-account-ca
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-pki
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/certificates/templates/server-certificates.yaml
+++ b/charts/certificates/templates/server-certificates.yaml
@@ -1,0 +1,240 @@
+{{- if .Values.certificates.kcp.certs -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  secretName: {{ include "kcp.fullname" . }}-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  {{- with .Values.certificates.subject }}
+  subject:
+    {{- toYaml . | nindent 4 }}
+  {{- end}}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - server auth
+  dnsNames:
+    - {{ include "kcp.fullname" . }}
+    {{- range .Values.certificates.dnsNames }}
+    - {{ . }}
+    {{- end }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-server-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}-virtual-workspaces
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  secretName: {{ include "kcp.fullname" . }}-virtual-workspaces-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  {{- with .Values.certificates.subject }}
+  subject:
+    {{- toYaml . | nindent 4 }}
+  {{- end}}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - server auth
+  dnsNames:
+  {{- range .Values.certificates.dnsNames }}
+  - {{ . }}
+  {{- end }}
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-server-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}-etcd-client
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  secretName: {{ include "kcp.fullname" . }}-etcd-client-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: {{ .Values.certificates.etcd.clientCertificate.commonName }}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  issuerRef:
+    {{- if .Values.certificates.etcd.clientCertificate.issuer }}
+    name: {{ .Values.certificates.etcd.clientCertificate.issuer }}
+    {{- else }}
+    name: {{ include "certificates.etcd" . }}-client-issuer
+    {{- end }}
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}-internal-admin-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  secretName: {{ include "kcp.fullname" . }}-internal-admin-kubeconfig-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: logical-cluster-admin
+  subject:
+    organizations:
+      - "system:kcp:logical-cluster-admin"
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}-external-admin-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  secretName: {{ include "kcp.fullname" . }}-external-admin-kubeconfig-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: external-logical-cluster-admin
+  subject:
+    organizations:
+      - "system:kcp:external-logical-cluster-admin"
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  issuerRef:
+    name: {{ include "certificates.frontproxy" . }}-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}-service-account
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: {{ include "kcp.fullname" . }}-service-account
+  secretName: {{ include "kcp.fullname" . }}-service-account-cert
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-service-account-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}-shard-client
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  secretName: {{ include "kcp.fullname" . }}-shard-client-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: {{ include "kcp.fullname" . }}
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  subject:
+    organizations:
+      - "system:masters"
+  usages:
+    - client auth
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/charts/certificates/templates/server-issuers.yaml
+++ b/charts/certificates/templates/server-issuers.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.certificates.kcp.pki -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.kcp" . }}-server-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  ca:
+    secretName: {{ include "certificates.kcp" . }}-ca
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.kcp" . }}-client-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  ca:
+    secretName: {{ include "certificates.kcp" . }}-client-ca
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.kcp" . }}-requestheader-client-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  ca:
+    secretName: {{ include "certificates.kcp" . }}-requestheader-client-ca
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "certificates.kcp" . }}-service-account-issuer
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  ca:
+    secretName: {{ include "certificates.kcp" . }}-service-account-ca
+{{- end }}

--- a/charts/certificates/values.yaml
+++ b/charts/certificates/values.yaml
@@ -1,0 +1,49 @@
+fullnameOverride: alpha
+externalHostname: "kcp.dev.local"
+
+certificates:
+  kcp:
+    pki: true
+    certs: true
+  frontproxy:
+    pki: true
+    certs: true
+  etcd:
+    pki: true
+    certs: true
+    # set this if you are using external or embedded etcds.
+    serverAddress: ""
+    clientCertificate:
+      # set this to a cert-manager Issuer that knows how to
+      # issue client certificates for your external etcd if
+      # you are not using the etcd provided by this chart.
+      issuer: ""
+      commonName: root
+  cache:
+    pki: false
+    certs: false
+  secretTemplate:
+    enabled: false
+    annotations: {}
+    labels: {}
+  privateKeys:
+    algorithm: RSA
+    size: 2048
+  subject: {}
+  # add additional dns names that should be embedded into the kcp server certificate.
+  dnsNames:
+  - localhost
+letsEncrypt:
+  enabled: false
+  staging:
+    enabled: false
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: ""
+  production:
+    enabled: false
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: ""

--- a/charts/kcp-sharded/Chart.yaml
+++ b/charts/kcp-sharded/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: kcp-sharded
+description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
+
+# version information
+version: 0.0.1
+appVersion: "0.21.0"
+
+# optional metadata
+type: application
+home: https://www.kcp.io/
+keywords:
+  - kcp
+  - kubernetes
+  - multitenancy
+  - controlplane
+sources:
+  - https://github.com/kcp-dev/helm-charts
+  - https://github.com/kcp-dev/kcp
+icon: https://raw.githubusercontent.com/kcp-dev/kcp/main/contrib/logo/blue-green.svg

--- a/charts/kcp-sharded/LICENSE
+++ b/charts/kcp-sharded/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/kcp-sharded/README.md
+++ b/charts/kcp-sharded/README.md
@@ -1,0 +1,9 @@
+# KCP Helm Chart - KCP Sharded
+
+This Helm chart deploys Sharded KCP.
+
+## Dependencies
+
+* cert-manager
+* Cache server deployed by [charts/cache](../../charts/cache)
+* Certificates deployed by [charts/certificates](../../charts/certificates)

--- a/charts/kcp-sharded/templates/_helpers.tpl
+++ b/charts/kcp-sharded/templates/_helpers.tpl
@@ -1,0 +1,104 @@
+{{- define "kcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.chartName" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.kcp" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kcp.version" -}}
+{{- if .Values.kcp.tag -}}
+{{- .Values.kcp.tag -}}
+{{- else -}}
+v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cache.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "frontproxy.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "certificates.cache" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.frontproxy" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "frontproxy.version" -}}
+{{- if .Values.kcpFrontProxy.tag -}}
+{{- .Values.kcpFrontProxy.tag -}}
+{{- else -}}
+v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.etcd" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "etcd.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "common.labels" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "kcp.chartName" . }}
+{{- end -}}
+
+{{- define "common.labels.selector" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/kcp-sharded/templates/etcd-statefulset.yaml
+++ b/charts/kcp-sharded/templates/etcd-statefulset.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.etcd.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "etcd.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  clusterIP: None
+  ports:
+    - port: 2379
+      name: client
+    - port: 2380
+      name: peer
+  selector:
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "etcd.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  serviceName: {{ include "etcd.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "etcd"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        {{- include "common.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "etcd"
+    spec:
+      containers:
+        - name: etcd
+          image: {{ .Values.etcd.image }}:{{ .Values.etcd.tag }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              PEERS="{{ include "etcd.fullname" . }}-0=https://{{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-1=https://{{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-2=https://{{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}:2380"
+              exec etcd --name ${HOSTNAME} \
+                --listen-peer-urls https://0.0.0.0:2380 \
+                --initial-advertise-peer-urls https://${HOSTNAME}:2380 \
+                --listen-client-urls https://0.0.0.0:2379 \
+                --advertise-client-urls https://${HOSTNAME}:2379 \
+                --initial-cluster-token etcd-cluster-1 \
+                --initial-cluster ${PEERS} \
+                --initial-cluster-state new \
+                --auto-compaction-mode=periodic \
+                --auto-compaction-retention=5m \
+                --data-dir /var/run/etcd/default.etcd \
+                --peer-client-cert-auth=true \
+                --peer-cert-file=/etc/etcd/tls/peer/tls.crt \
+                --peer-key-file=/etc/etcd/tls/peer/tls.key \
+                --peer-trusted-ca-file=/etc/etcd/tls/peer-ca/tls.crt \
+                --client-cert-auth=true \
+                --cert-file=/etc/etcd/tls/server/tls.crt \
+                --key-file=/etc/etcd/tls/server/tls.key \
+                --trusted-ca-file=/etc/etcd/tls/client-ca/tls.crt \
+                {{- if .Values.etcd.profiling.enabled }}
+                --enable-pprof=true \
+                {{- end }}
+                --snapshot-count=5000
+          ports:
+            - containerPort: 2379
+              name: client
+            - containerPort: 2380
+              name: peer
+          {{- with .Values.etcd.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: etcd-data
+              mountPath: /var/run/etcd
+            - name: peer-cert
+              mountPath: /etc/etcd/tls/peer
+            - name: peer-ca
+              mountPath: /etc/etcd/tls/peer-ca
+            - name: server-cert
+              mountPath: /etc/etcd/tls/server
+            - name: client-ca
+              mountPath: /etc/etcd/tls/client-ca
+      volumes:
+        - name: peer-cert
+          secret:
+            secretName: {{ include "etcd.fullname" . }}-peer-cert
+        - name: server-cert
+          secret:
+            secretName: {{ include "etcd.fullname" . }}-cert
+        - name: peer-ca
+          secret:
+            secretName: {{ include "certificates.etcd" . }}-peer-ca
+        - name: client-ca
+          secret:
+            secretName: {{ include "certificates.etcd" . }}-client-ca
+  volumeClaimTemplates:
+    - metadata:
+        name: etcd-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.etcd.volumeSize }}
+{{- end }}

--- a/charts/kcp-sharded/templates/server-deployment.yaml
+++ b/charts/kcp-sharded/templates/server-deployment.yaml
@@ -1,0 +1,391 @@
+{{- if .Values.kcp.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kcp.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.kcp.volumeSize }}
+  {{ with .Values.kcp.volumeClassName -}}storageClassName: {{ . }}{{- end }}
+{{- if .Values.audit.enabled }}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kcp.fullname" . }}-audit-logs
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.audit.volumeSize }}
+  {{- with .Values.audit.volumeClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kcp.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  ports:
+    - protocol: TCP
+      name: kcp
+      port: 6443
+      targetPort: 6443
+    - protocol: TCP
+      name: virtual-workspaces
+      port: 6444
+      targetPort: 6444
+  selector:
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kcp.fullname" . }}-internal
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  ports:
+    - protocol: TCP
+      name: kcp
+      port: 443
+      targetPort: 6443
+    - protocol: TCP
+      name: virtual-workspaces
+      port: 444
+      targetPort: 6444
+  selector:
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kcp.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "server"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "common.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "server"
+    spec:
+      {{- with .Values.kcp.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kcp.hostAliases.enabled }}
+      hostAliases:
+        {{- toYaml .Values.kcp.hostAliases.values | nindent 6 }}
+      {{- end }}
+      containers:
+        - name: kcp
+          image: {{ .Values.kcp.image }}:{{- include "kcp.version" . }}
+          imagePullPolicy: {{ .Values.kcp.pullPolicy }}
+          ports:
+            - containerPort: 6443
+            {{- if .Values.kcp.profiling.enabled }}
+            - containerPort: {{ .Values.kcp.profiling.port }}
+              name: profiler
+            {{- end}}
+          command: ["/kcp", "start"]
+          args:
+            {{- if .Values.sharding.enabled }}
+            {{- if .Values.sharding.isShard }}
+            - --shard-name={{ include "kcp.fullname" . }}
+            - --root-shard-kubeconfig-file=/etc/kcp/shard/kubeconfig
+            {{- end }}
+            - --shard-client-cert-file=/etc/kcp/tls/shard-client/tls.crt
+            - --shard-client-key-file=/etc/kcp/tls/shard-client/tls.key
+            {{- end }}
+            {{- if .Values.kcp.etcd.serverAddress }}
+            - --etcd-servers={{ .Values.kcp.etcd.serverAddress }}
+            {{- else if .Values.etcd.enabled }}
+            - --etcd-servers=https://{{ include "etcd.fullname" . }}:2379
+            {{- end }}
+            {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}
+            - --etcd-keyfile=/etc/kcp/tls/etcd-client/tls.key
+            - --etcd-certfile=/etc/kcp/tls/etcd-client/tls.crt
+            - --etcd-cafile=/etc/etcd/tls/client-ca/tls.crt
+            {{- end }}
+            - --client-ca-file=/etc/kcp/tls/client-ca/tls.crt
+            - --tls-private-key-file=/etc/kcp/tls/server/tls.key
+            - --tls-cert-file=/etc/kcp/tls/server/tls.crt
+            - --service-account-key-file=/etc/kcp/tls/service-account/tls.key
+            - --service-account-private-key-file=/etc/kcp/tls/service-account/tls.key
+            - --root-ca-file=/etc/kcp/tls/service-account-ca/tls.crt
+            - --enable-home-workspaces={{ .Values.kcp.homeWorkspaces.enabled }}
+            {{- if .Values.kcp.logicalClusterAdminFlag }}
+            - --logical-cluster-admin-kubeconfig=/etc/kcp/logical-cluster-admin/kubeconfig/kubeconfig
+            {{- end }}
+            - --external-logical-cluster-admin-kubeconfig=/etc/kcp/external-logical-cluster-admin/kubeconfig/kubeconfig
+            - --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client-ca/tls.crt
+            - --requestheader-username-headers=X-Remote-User
+            - --requestheader-group-headers=X-Remote-Group
+            - --root-directory=/etc/kcp/config
+            - --shard-virtual-workspace-ca-file=/etc/kcp/tls/ca/tls.crt
+            {{- if .Values.sharding.enabled }}
+            {{- if .Values.sharding.isRoot }}
+            - --external-hostname={{ include "kcp.fullname" . }}.{{ .Release.Namespace }}:6443
+            - --shard-external-url=https://$(EXTERNAL_HOSTNAME):$(EXTERNAL_PORT)
+            {{- else }}
+            - --external-hostname={{ include "kcp.fullname" . }}.{{ .Release.Namespace }}:6443
+            - --shard-external-url=https://$(EXTERNAL_HOSTNAME):$(EXTERNAL_PORT)
+            {{- end }}
+            {{- end }}
+            {{- if .Values.oidc.enabled }}
+            - --oidc-issuer-url={{ .Values.oidc.issuerUrl }}
+            - --oidc-client-id={{ .Values.oidc.clientId }}
+            - --oidc-groups-claim={{ .Values.oidc.groupClaim }}
+            - --oidc-username-claim={{ .Values.oidc.usernameClaim }}
+            - '--oidc-username-prefix={{ .Values.oidc.usernamePrefix }}'
+            - '--oidc-groups-prefix={{ .Values.oidc.groupsPrefix }}'
+            {{- if .Values.oidc.caSecretName }}
+            - --oidc-ca-file=/etc/kcp/tls/oidc/{{ .Values.oidc.caSecretKeyName }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.kcp.tokenAuth.enabled }}
+            - --token-auth-file=/etc/kcp/token-auth/{{ .Values.kcp.tokenAuth.fileName }}
+            {{- end }}
+            - --v={{ .Values.kcp.v }}
+            - --logging-format=json
+            {{- if .Values.audit.enabled }}
+            - --audit-log-maxage={{ .Values.audit.log.maxAge }}
+            - --audit-log-maxbackup={{ .Values.audit.log.maxBackup }}
+            - --audit-log-maxsize={{ .Values.audit.log.maxSize }}
+            - --audit-log-path={{ .Values.audit.log.dir }}/kcp.log
+            - --audit-policy-file={{ .Values.audit.policy.dir }}/{{ .Values.audit.policy.fileName }}
+            - --audit-log-compress
+            - --audit-log-format=json
+            {{- end }}
+            {{- if .Values.kcp.profiling.enabled }}
+            - --profiler-address=0.0.0.0:{{- .Values.kcp.profiling.port -}}
+            {{- end }}
+            {{- if or (eq .Values.cache.enabled true) (eq .Values.externalCache.enabled true) }}
+            - --cache-kubeconfig=/etc/kcp/cache/kubeconfig/kubeconfig
+            {{- end }}
+            {{- with .Values.kcp.batteries }}
+            - --batteries-included={{ join "," . }}
+            {{- end }}
+            {{- range .Values.kcp.extraFlags }}
+            - {{ . }}
+            {{- end }}
+          env:
+            - name: EXTERNAL_HOSTNAME
+              value: {{ required "A valid external hostname is required" .Values.externalHostname }}
+            - name: EXTERNAL_PORT
+              value: "{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.memory
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: livez
+              port: 6443
+              scheme: HTTPS
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          startupProbe:
+            httpGet:
+              path: readyz
+              port: 6443
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 36
+          readinessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: readyz
+              port: 6443
+              scheme: HTTPS
+          {{- with .Values.kcp.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}
+            - name: kcp-etcd-client-cert
+              mountPath: /etc/kcp/tls/etcd-client
+            - name: etcd-client-ca
+              mountPath: /etc/etcd/tls/client-ca
+            {{- end }}
+            - name: kcp-ca
+              mountPath: /etc/kcp/tls/ca
+            - name: kcp-cert
+              mountPath: /etc/kcp/tls/server
+            - name: kcp-client-ca
+              mountPath: /etc/kcp/tls/client-ca
+            - name: kcp-service-account-cert
+              mountPath: /etc/kcp/tls/service-account
+            - name: kcp-service-account-ca
+              mountPath: /etc/kcp/tls/service-account-ca
+            - name: kcp-requestheader-client-ca
+              mountPath: /etc/kcp/tls/requestheader-client-ca
+            {{- if .Values.oidc.enabled }}
+            {{- if .Values.oidc.caSecretName }}
+            - name: oidc-ca
+              mountPath: /etc/kcp/tls/oidc
+            {{- end }}
+            {{- end }}
+            {{- if .Values.kcp.tokenAuth.enabled }}
+            - name: kcp-token-auth-file
+              mountPath: /etc/kcp/token-auth
+            {{- end}}
+            {{- if .Values.audit.enabled }}
+            - name: audit-log
+              mountPath: {{ .Values.audit.log.dir }}
+            - name: audit-policy
+              mountPath: {{ .Values.audit.policy.dir }}
+            {{- end }}
+            - name: logical-cluster-admin-kubeconfig
+              mountPath: /etc/kcp/logical-cluster-admin/kubeconfig
+            - name: logical-cluster-admin-kubeconfig-cert
+              mountPath: /etc/kcp/logical-cluster-admin/kubeconfig-client-cert
+            - name: external-logical-cluster-admin-kubeconfig
+              mountPath: /etc/kcp/external-logical-cluster-admin/kubeconfig
+            - name: external-logical-cluster-admin-kubeconfig-cert
+              mountPath: /etc/kcp/external-logical-cluster-admin/kubeconfig-client-cert
+            - name: kcp-config
+              mountPath: /etc/kcp/config
+            {{- if .Values.sharding.enabled }}
+            - name: kcp-shard-client-cert
+              mountPath: /etc/kcp/tls/shard-client
+            - name: kcp-shard-kubeconfig
+              mountPath: /etc/kcp/shard
+            {{- end }}
+            {{- if or (eq .Values.cache.enabled true) (eq .Values.externalCache.enabled true) }}
+            - name: kcp-cache-kubeconfig
+              mountPath: /etc/kcp/cache/kubeconfig
+            {{- end }}
+      volumes:
+        {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}
+        - name: kcp-etcd-client-cert
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-etcd-client-cert
+        - name: etcd-client-ca
+          secret:
+            secretName: {{ include "certificates.etcd" . }}-client-ca
+        {{- end }}
+        - name: kcp-ca
+          secret:
+            secretName: {{ include "certificates.kcp" . }}-ca
+        - name: kcp-cert
+          secret:
+            secretName: {{ include "kcp.fullname" .}}-cert
+        - name: kcp-client-ca
+          secret:
+            secretName: {{ include "certificates.kcp" . }}-client-ca
+        - name: kcp-service-account-cert
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-service-account-cert
+        - name: kcp-service-account-ca
+          secret:
+            secretName: {{ include "certificates.kcp" . }}-service-account-ca
+        - name: kcp-requestheader-client-ca
+          secret:
+            secretName: {{ include "certificates.kcp" . }}-requestheader-client-ca
+        {{- if .Values.oidc.enabled }}
+        {{- if .Values.oidc.caSecretName }}
+        - name: oidc-ca
+          secret:
+            secretName: {{.Values.oidc.caSecretName }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.kcp.tokenAuth.enabled }}
+        - name: kcp-token-auth-file
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-token-auth-file
+        {{- end }}
+        {{- if .Values.audit.enabled }}
+        - name: audit-policy
+          configMap:
+            name: {{ include "kcp.fullname" . }}-audit-policy
+        - name: audit-log
+          persistentVolumeClaim:
+            claimName: {{ include "kcp.fullname" . }}-audit-logs
+        {{- end }}
+        - name: logical-cluster-admin-kubeconfig
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-internal-admin-kubeconfig
+        - name: logical-cluster-admin-kubeconfig-cert
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-internal-admin-kubeconfig-cert
+        - name: external-logical-cluster-admin-kubeconfig
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-external-admin-kubeconfig
+        - name: external-logical-cluster-admin-kubeconfig-cert
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-external-admin-kubeconfig-cert
+        - name: kcp-config
+          persistentVolumeClaim:
+            claimName: {{ include "kcp.fullname" . }}
+        {{- if .Values.sharding.enabled }}
+        - name: kcp-shard-client-cert
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-shard-client-cert
+        - name: kcp-shard-kubeconfig
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-shard-admin-kubeconfig
+        {{- end }}
+        {{- if or (eq .Values.cache.enabled true) (eq .Values.externalCache.enabled true) }}
+        - name: kcp-cache-kubeconfig
+          secret:
+            secretName: {{ include "cache.fullname" .}}-kubeconfig
+        {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kcp.fullname" . }}-audit-policy
+data:
+  {{ .Values.audit.policy.fileName }}: |
+    {{- .Values.audit.policy.config | nindent 4 }}
+
+{{- if .Values.kcp.tokenAuth.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kcp.fullname" . }}-token-auth-file
+stringData:
+  {{ .Values.kcp.tokenAuth.fileName }}: |
+    {{- .Values.kcp.tokenAuth.config | nindent 4 }}
+{{- end}}
+{{- end }}

--- a/charts/kcp-sharded/templates/server-kubeconfigs.yaml
+++ b/charts/kcp-sharded/templates/server-kubeconfigs.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.kcp.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kcp.fullname" .}}-internal-admin-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: logical-cluster:admin
+        cluster:
+          # this references the CA certificate that signed kcp's serving certificate
+          # (kcp-server-issuer by default)
+          certificate-authority: /etc/kcp/tls/ca/tls.crt
+          server: "https://{{ include "kcp.fullname" . }}:6443"
+    contexts:
+      - name: logical-cluster
+        context:
+          cluster: logical-cluster:admin
+          user: logical-cluster-admin
+    current-context: logical-cluster
+    users:
+      - name: logical-cluster-admin
+        user:
+          client-certificate: /etc/kcp/logical-cluster-admin/kubeconfig-client-cert/tls.crt
+          client-key: /etc/kcp/logical-cluster-admin/kubeconfig-client-cert/tls.key
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kcp.fullname" . }}-external-admin-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: external-logical-cluster-admin
+        cluster:
+          # this references the CA certificate that signed the kcp-front-proxy's certificate
+          # (kcp-server-issuer by default, but could also be any other, external CA)
+          certificate-authority: /etc/kcp/tls/ca/tls.crt
+          server: "https://{{ .Values.externalHostname }}:{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}"
+    contexts:
+      - name: external-logical-cluster
+        context:
+          cluster: external-logical-cluster-admin
+          user: external-logical-cluster-admin
+    current-context: external-logical-cluster
+    users:
+      - name: external-logical-cluster-admin
+        user:
+          client-certificate: /etc/kcp/external-logical-cluster-admin/kubeconfig-client-cert/tls.crt
+          client-key: /etc/kcp/external-logical-cluster-admin/kubeconfig-client-cert/tls.key
+{{- end }}
+{{- if .Values.sharding.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kcp.fullname" .}}-shard-admin-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: system:admin
+        cluster:
+          # this references the CA certificate that signed kcp's serving certificate
+          # (kcp-server-issuer by default)
+          certificate-authority: /etc/kcp/tls/ca/tls.crt
+          server: "https://{{ .Values.sharding.rootShardInternalHostname }}:6443"
+    contexts:
+      - name: shard-base
+        context:
+          cluster: system:admin
+          user: system:admin
+    current-context: system:admin
+    users:
+      - name: system:admin
+        user:
+          client-certificate: /etc/kcp/tls/shard-client/tls.crt
+          client-key: /etc/kcp/tls/shard-client/tls.key
+{{- end }}
+{{- if .Values.externalCache.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cache.fullname" .}}-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "cache"
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority: /etc/kcp/tls/ca/tls.crt
+        server: "https://{{ .Values.externalCache.cacheInternalHostname }}:8012"
+      name: cache
+    contexts:
+    - context:
+        cluster: cache
+        user: ""
+      name: cache
+    current-context: cache
+    kind: Config
+    preferences: {}
+    users: null
+{{- end }}

--- a/charts/kcp-sharded/values.yaml
+++ b/charts/kcp-sharded/values.yaml
@@ -1,0 +1,115 @@
+externalHostname: ""
+etcd:
+  enabled: true
+  image: quay.io/coreos/etcd
+  tag: v3.5.4
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      # cpu: 1
+     memory: 20Gi
+  volumeSize: 8Gi
+  profiling:
+    enabled: false
+kcp:
+  enabled: true
+  sharding:
+    enabled: false
+    isShard: false # set this to true for the all shards, false for the first (root) shard.
+    isRoot: true # set this to true for the first (root) shard, false for all other shards.
+    rootShardInternalHostname: "" # set this to the internal hostname of the root shard.
+  image: ghcr.io/kcp-dev/kcp
+  # set this to override the image tag used for kcp (determined by chart appVersion by default).
+  tag: ""
+  pullPolicy: IfNotPresent
+  v: "3"
+  logicalClusterAdminFlag: true
+  externalLogicalClusterAdminFlag: true
+  # enabled "batteries" (see kcp start --help for available batteries).
+  batteries:
+    - workspace-types
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 100m
+    limits:
+      # cpu: 1
+      memory: 20Gi
+  volumeClassName: ""
+  etcd:
+    # set this if you are using external or embedded etcds.
+    serverAddress: ""
+    clientCertificate:
+      # set this to a cert-manager Issuer that knows how to
+      # issue client certificates for your external etcd if
+      # you are not using the etcd provided by this chart.
+      issuer: ""
+      commonName: root
+  volumeSize: 1Gi
+  extraFlags: []
+  profiling:
+    enabled: false
+    port: 6060
+  tokenAuth:
+    enabled: false
+    fileName: auth-token.csv
+    config: |
+        user-1-token,user-1,1111-1111-1111-1111,"team-1"
+        admin-token,admin,5555-5555-5555-5555,"system:kcp:admin"
+        system-token,system,6666-6666-6666-6666,"system:masters"
+  hostAliases:
+    enabled: false
+  homeWorkspaces:
+    enabled: false
+  securityContext:
+    # this matches the group id as set in the kcp Dockerfile.
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+kcpFrontProxy:
+  service:
+    annotations: {}
+    # set this to LoadBalancer if you want to publish kcp-front-proxy
+    # directly instead of going via Route/Ingress/Gateway resources.
+    type: ClusterIP
+  # set this if you want kcp-front-proxy to use a specific certificate issuer
+  # (e.g. the Let's Encrypt ones in this chart).
+  # certificateIssuer:
+  #   name: ""
+  #   kind: Issuer
+audit:
+  enabled: false
+  volumeSize: 1Gi
+  volumeClassName: ""
+  policy:
+    dir: /etc/kcp/audit
+    fileName: audit-policy.yml
+    config: |
+      # Log all requests at the Metadata level.
+      apiVersion: audit.k8s.io/v1
+      kind: Policy
+      rules:
+      - level: Metadata
+  log:
+    maxAge: "10"
+    maxSize: "250"
+    maxBackup: "1"
+    dir: /var/audit
+oidc:
+  enabled: false
+  caSecretName: ""
+  # assuming you're using cert-manager, you want to mount the CA certificate
+  # directly and use its tls.crt key; if you instead mount a certificate that
+  # is _signed by_ the OIDC CA, then do not use its ca.crt key, as it is the
+  # absolute top root CA, the CA that actually signed the cert is one of the
+  # certs in the tls.crt chain. As you cannot say "use this Secret, but the
+  # second cert in the tls.crt key", it's easier to mount the CA cert secret.
+  caSecretKeyName: "tls.crt"
+
+cache:
+  enabled: false
+
+certificates:
+  name: certs

--- a/charts/proxy/Chart.yaml
+++ b/charts/proxy/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: kcp
+description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
+
+# version information
+version: 0.4.4
+appVersion: "0.21.0"
+
+# optional metadata
+type: application
+home: https://www.kcp.io/
+keywords:
+  - kcp
+  - kubernetes
+  - multitenancy
+  - controlplane
+sources:
+  - https://github.com/kcp-dev/helm-charts
+  - https://github.com/kcp-dev/kcp
+icon: https://raw.githubusercontent.com/kcp-dev/kcp/main/contrib/logo/blue-green.svg

--- a/charts/proxy/LICENSE
+++ b/charts/proxy/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/proxy/README.md
+++ b/charts/proxy/README.md
@@ -1,0 +1,10 @@
+# KCP Helm Chart - Front Proxy
+
+This Helm chart deploys Sharded KCP.
+
+## Dependencies
+
+* cert-manager
+* Cache server deployed by [charts/cache](../../charts/cache)
+* Certificates deployed by [charts/certificates](../../charts/certificates)
+* Single shard deployed by [charts/kcp-sharded](../../charts/kcp-sharded)

--- a/charts/proxy/templates/_helpers.tpl
+++ b/charts/proxy/templates/_helpers.tpl
@@ -1,0 +1,104 @@
+{{- define "kcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.chartName" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kcp.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.kcp" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-kcp" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kcp.version" -}}
+{{- if .Values.kcp.tag -}}
+{{- .Values.kcp.tag -}}
+{{- else -}}
+v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cache.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "frontproxy.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "certificates.cache" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.frontproxy" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "frontproxy.version" -}}
+{{- if .Values.kcpFrontProxy.tag -}}
+{{- .Values.kcpFrontProxy.tag -}}
+{{- else -}}
+v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "certificates.etcd" -}}
+{{- if not (eq .Values.certificates.name "") -}}
+{{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "etcd.fullname" -}}
+{{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
+{{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "common.labels" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "kcp.chartName" . }}
+{{- end -}}
+
+{{- define "common.labels.selector" -}}
+app.kubernetes.io/name: {{ template "kcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/proxy/templates/front-proxy-configmap.yaml
+++ b/charts/proxy/templates/front-proxy-configmap.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.kcpFrontProxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-config
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+data:
+  path-mapping.yaml: |
+    - path: /clusters/
+      backend: https://{{ include "kcp.fullname" . }}:6443
+      backend_server_ca: /etc/kcp/tls/ca/tls.crt
+      proxy_client_cert: /etc/kcp-front-proxy/requestheader-client/tls.crt
+      proxy_client_key: /etc/kcp-front-proxy/requestheader-client/tls.key
+    - path: /services/
+      backend: https://{{ include "kcp.fullname" . }}:6443
+      backend_server_ca: /etc/kcp/tls/ca/tls.crt
+      proxy_client_cert: /etc/kcp-front-proxy/requestheader-client/tls.crt
+      proxy_client_key: /etc/kcp-front-proxy/requestheader-client/tls.key
+    {{- with .Values.kcpFrontProxy.additionalPathMappings }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/proxy/templates/front-proxy-deployment.yaml
+++ b/charts/proxy/templates/front-proxy-deployment.yaml
@@ -1,0 +1,227 @@
+{{- if .Values.kcpFrontProxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "frontproxy.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+  {{- with .Values.kcpFrontProxy.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.kcpFrontProxy.service.type }}
+  ports:
+    - protocol: TCP
+      name: kcp-front-proxy
+      port: 8443
+      targetPort: 8443
+  selector:
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-internal
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+  {{- with .Values.kcpFrontProxy.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.kcpFrontProxy.service.type }}
+  ports:
+    - protocol: TCP
+      name: kcp-front-proxy
+      port: 443
+      targetPort: 8443
+  selector:
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "frontproxy.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "front-proxy"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "common.labels" . | nindent 8 }}
+        app.kubernetes.io/component: "front-proxy"
+    spec:
+      {{- with .Values.kcpFrontProxy.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.kcpFrontProxy.hostAliases.enabled }}
+      hostAliases:
+        {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 6 }}
+      {{- end }}
+      containers:
+        - name: kcp-front-proxy
+          image: "{{ .Values.kcpFrontProxy.image }}:{{- include "frontproxy.version" . }}"
+          imagePullPolicy: {{ .Values.kcpFrontProxy.pullPolicy }}
+          command: ["/kcp-front-proxy"]
+          args:
+            - --secure-port=8443
+            - --root-kubeconfig=/etc/kcp-front-proxy/kubeconfig/kubeconfig
+            - --shards-kubeconfig=/etc/kcp-front-proxy/shards/kubeconfig
+            - --tls-private-key-file=/etc/kcp-front-proxy/tls/tls.key
+            - --tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt
+            - --client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt
+            - --service-account-key-file=/etc/kcp/tls/service-account/tls.key
+            - --mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml
+            - --v={{ .Values.kcpFrontProxy.v }}
+            - --logging-format=json
+            {{- if .Values.kcpFrontProxy.profiling.enabled }}
+            - --profiler-address=localhost:{{- .Values.kcpFrontProxy.profiling.port -}}
+            {{- end }}
+            {{- if .Values.oidc.enabled }}
+            - --oidc-issuer-url={{ .Values.oidc.issuerUrl }}
+            - --oidc-client-id={{ .Values.oidc.clientId }}
+            - --oidc-groups-claim={{ .Values.oidc.groupClaim }}
+            - --oidc-username-claim={{ .Values.oidc.usernameClaim }}
+            - '--oidc-username-prefix={{ .Values.oidc.usernamePrefix }}'
+            - '--oidc-groups-prefix={{ .Values.oidc.groupsPrefix }}'
+            {{- if .Values.oidc.caSecretName }}
+            - --oidc-ca-file=/etc/kcp/tls/oidc/{{ .Values.oidc.caSecretKeyName }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.kcpFrontProxy.tokenAuth.enabled }}
+            - --token-auth-file=/etc/kcp/token-auth/{{ .Values.kcpFrontProxy.tokenAuth.fileName }}
+            {{- end }}
+            {{- range .Values.kcpFrontProxy.extraFlags }}
+            - {{ . }}
+            {{- end }}
+          ports:
+            - containerPort: 8443
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: livez
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: readyz
+              port: 8443
+              scheme: HTTPS
+          {{- with .Values.kcpFrontProxy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: kcp-front-proxy-kubeconfig
+              mountPath: /etc/kcp-front-proxy/kubeconfig
+            # this mount is necessary for the paths referenced in kcp-front-proxy-kubeconfig
+            - name: kubeconfig-client-cert
+              mountPath: /etc/kcp-front-proxy/kubeconfig-client-cert
+            - name: kcp-front-proxy-cert
+              mountPath: /etc/kcp-front-proxy/tls
+            - name: kcp-front-proxy-client-ca
+              mountPath: /etc/kcp-front-proxy/client-ca
+            - name: kcp-service-account-cert
+              mountPath: /etc/kcp/tls/service-account
+            - name: kcp-front-proxy-config
+              mountPath: /etc/kcp-front-proxy/config
+            {{- if .Values.oidc.enabled }}
+            {{- if .Values.oidc.caSecretName }}
+            - name: oidc-ca
+              mountPath: /etc/kcp/tls/oidc
+            {{- end }}
+            {{- end }}
+            {{- if .Values.kcpFrontProxy.tokenAuth.enabled }}
+            - name: kcp-token-auth-file
+              mountPath: /etc/kcp/token-auth
+            {{- end}}
+            # these mounts are required for the path-mapping.yaml, which references specific certificates
+            - name: kcp-ca
+              mountPath: /etc/kcp/tls/ca
+            - name: kcp-requestheader-client-cert
+              mountPath: /etc/kcp-front-proxy/requestheader-client
+            - name: kcp-shard-client-cert
+              mountPath: /etc/kcp/tls/shard-client
+            - name: kcp-shards-kubeconfig
+              mountPath: /etc/kcp-front-proxy/shards
+{{- with .Values.kcpFrontProxy.extraVolumeMounts }}
+{{ . | toYaml | indent 12 }}
+{{- end }}
+      volumes:
+        - name: kcp-front-proxy-kubeconfig
+          secret:
+            secretName: {{ include "frontproxy.fullname" . }}-kubeconfig
+        # this mount is necessary for the paths referenced in kcp-front-proxy-kubeconfig
+        - name: kubeconfig-client-cert
+          secret:
+            secretName: {{ include "frontproxy.fullname" . }}-kubeconfig-cert
+        - name: kcp-front-proxy-cert
+          secret:
+            secretName: {{ include "frontproxy.fullname" . }}-cert
+        - name: kcp-front-proxy-client-ca
+          secret:
+            secretName: {{ include "certificates.frontproxy" . }}-client-ca
+        - name: kcp-service-account-cert
+          secret:
+            secretName: {{ include "frontproxy.fullname" . }}-service-account-cert
+        - name: kcp-front-proxy-config
+          configMap:
+            name: {{ include "frontproxy.fullname" . }}-config
+        {{- if .Values.oidc.enabled }}
+        {{- if .Values.oidc.caSecretName }}
+        - name: oidc-ca
+          secret:
+            secretName: {{.Values.oidc.caSecretName }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.kcpFrontProxy.tokenAuth.enabled }}
+        - name: kcp-token-auth-file
+          secret:
+            secretName: {{ include "frontproxy.fullname" . }}-token-auth-file
+        {{- end }}
+        # these volumes are necessary for the path-mapping.yaml
+        - name: kcp-ca
+          secret:
+            secretName: {{ include "certificates.kcp" . }}-ca
+        - name: kcp-requestheader-client-cert
+          secret:
+            secretName: {{ include "frontproxy.fullname" . }}-requestheader-cert
+        - name: kcp-shard-client-cert
+          secret:
+            secretName: {{ include "frontproxy.fullname" . }}-shard-client-cert
+        - name: kcp-shards-kubeconfig
+          secret:
+            secretName: {{ include "frontproxy.fullname" . }}-shard-admin-kubeconfig
+{{- with .Values.kcpFrontProxy.extraVolumes }}
+{{ . | toYaml | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if .Values.kcpFrontProxy.tokenAuth.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-token-auth-file
+stringData:
+  {{ .Values.kcpFrontProxy.tokenAuth.fileName }}: |
+    {{- .Values.kcpFrontProxy.tokenAuth.config | nindent 4 }}
+{{- end}}

--- a/charts/proxy/templates/front-proxy-ingress.yaml
+++ b/charts/proxy/templates/front-proxy-ingress.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.kcpFrontProxy.enabled }}
+{{- if .Values.kcpFrontProxy.openshiftRoute.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "frontproxy.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  host: {{ .Values.externalHostname }}
+  port:
+    targetPort: 8443
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+    name: {{ include "frontproxy.fullname" . }}
+    weight: 100
+  wildcardPolicy: None
+{{- end }}
+
+{{- if .Values.kcpFrontProxy.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "frontproxy.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+  annotations:
+    {{- toYaml .Values.kcpFrontProxy.ingress.annotations | nindent 4 }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.externalHostname }}
+      {{- if .Values.kcpFrontProxy.ingress.secret }}
+      secretName: {{ .Values.kcpFrontProxy.ingress.secret }}
+      {{- end }}
+  rules:
+    - host: {{ .Values.externalHostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "frontproxy.fullname" . }}
+                port:
+                  number: 8443
+{{- end }}
+
+{{- if .Values.kcpFrontProxy.gateway.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ include "frontproxy.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  gatewayClassName: {{ required "gateway.classname is required" .Values.kcpFrontProxy.gateway.className }}
+  listeners:
+    - name: tls
+      protocol: TLS
+      port: 8443
+      tls:
+        mode: Passthrough
+      hostname: {{ .Values.externalHostname }}
+
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: {{ include "frontproxy.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: {{ include "frontproxy.fullname" . }}
+  rules:
+    - backendRefs:
+        - name: {{ include "frontproxy.fullname" . }}
+          port: 8443
+  hostnames:
+    - {{ .Values.externalHostname }}
+{{- end }}
+{{- end }}

--- a/charts/proxy/templates/front-proxy-kubeconfig.yaml
+++ b/charts/proxy/templates/front-proxy-kubeconfig.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.kcpFrontProxy.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: system:admin
+        cluster:
+          # this references the CA certificate that signed kcp's serving certificate
+          # (kcp-server-issuer by default)
+          certificate-authority: /etc/kcp/tls/ca/tls.crt
+          server: "https://{{ .Values.sharding.rootShardInternalHostname }}:6443"
+    contexts:
+      - name: system:admin
+        context:
+          cluster: system:admin
+          user: admin
+    current-context: system:admin
+    users:
+      - name: admin
+        user:
+          client-certificate: /etc/kcp-front-proxy/kubeconfig-client-cert/tls.crt
+          client-key: /etc/kcp-front-proxy/kubeconfig-client-cert/tls.key
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-shard-admin-kubeconfig
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+type: Opaque
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: system:admin
+        cluster:
+          # this references the CA certificate that signed kcp's serving certificate
+          # (kcp-server-issuer by default)
+          certificate-authority: /etc/kcp/tls/ca/tls.crt
+          server: "https://{{ .Values.sharding.rootShardInternalHostname }}:6443"
+    contexts:
+      - name: system:admin
+        context:
+          cluster: system:admin
+          user: system:admin
+    current-context: system:admin
+    users:
+      - name: system:admin
+        user:
+          client-certificate: /etc/kcp/tls/shard-client/tls.crt
+          client-key: /etc/kcp/tls/shard-client/tls.key
+{{- end }}

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -1,0 +1,245 @@
+externalHostname: ""
+etcd:
+  enabled: true
+  image: quay.io/coreos/etcd
+  tag: v3.5.4
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      # cpu: 1
+     memory: 20Gi
+  volumeSize: 8Gi
+  profiling:
+    enabled: false
+kcp:
+  enabled: true
+  image: ghcr.io/kcp-dev/kcp
+  # set this to override the image tag used for kcp (determined by chart appVersion by default).
+  tag: ""
+  pullPolicy: IfNotPresent
+  v: "3"
+  logicalClusterAdminFlag: true
+  externalLogicalClusterAdminFlag: true
+  # enabled "batteries" (see kcp start --help for available batteries).
+  batteries:
+    - workspace-types
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 100m
+    limits:
+      # cpu: 1
+      memory: 20Gi
+  volumeClassName: ""
+  etcd:
+    # set this if you are using external or embedded etcds.
+    serverAddress: ""
+    clientCertificate:
+      # set this to a cert-manager Issuer that knows how to
+      # issue client certificates for your external etcd if
+      # you are not using the etcd provided by this chart.
+      issuer: ""
+      commonName: root
+  volumeSize: 1Gi
+  extraFlags: []
+  profiling:
+    enabled: false
+    port: 6060
+  tokenAuth:
+    enabled: false
+    fileName: auth-token.csv
+    config: |
+        user-1-token,user-1,1111-1111-1111-1111,"team-1"
+        admin-token,admin,5555-5555-5555-5555,"system:kcp:admin"
+        system-token,system,6666-6666-6666-6666,"system:masters"
+  hostAliases:
+    enabled: false
+  homeWorkspaces:
+    enabled: false
+  securityContext:
+    # this matches the group id as set in the kcp Dockerfile.
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+kcpFrontProxy:
+  enabled: true
+  image: ghcr.io/kcp-dev/kcp
+  # set this to override the image tag used for kcp-front-proxy (determined by chart appVersion by default).
+  tag: ""
+  pullPolicy: IfNotPresent
+  v: "4"
+  tokenAuth:
+    enabled: false
+    fileName: auth-token.csv
+    config: |
+        user-1-token,user-1,1111-1111-1111-1111,"team-1"
+        admin-token,admin,5555-5555-5555-5555,"system:kcp:admin"
+        system-token,system,6666-6666-6666-6666,"system:masters"
+  openshiftRoute:
+    enabled: false
+  ingress:
+    enabled: false
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      acme.cert-manager.io/http01-edit-in-place: "true"
+      # this is ingress-controller-specific and might need configuration
+      # depending on the ingress-controller in use.
+      nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    secret: ""
+  gateway:
+    enabled: false
+    className: ""
+  service:
+    annotations: {}
+    # set this to LoadBalancer if you want to publish kcp-front-proxy
+    # directly instead of going via Route/Ingress/Gateway resources.
+    type: ClusterIP
+  # set this if you want kcp-front-proxy to use a specific certificate issuer
+  # (e.g. the Let's Encrypt ones in this chart).
+  # certificateIssuer:
+  #   name: ""
+  #   kind: Issuer
+  profiling:
+    enabled: false
+    port: 6060
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      # cpu: 1
+      memory: 1Gi
+  hostAliases:
+    enabled: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  # The default virtual workspaces run in-process, but you can
+  # extend the path mapping to include custom virtual workspaces
+  # in the front-proxy's routing.
+  additionalPathMappings: []
+  #- path: /services/...
+  #  backend: https://your-external-virtual-workspaces-server:6443
+  # backend_server_ca: /etc/kcp/tls/ca.crt # if your server used a cert from the kcp-server-issuer
+  #  proxy_client_cert: /etc/kcp-front-proxy/requestheader-client/tls/kcp/tls.crt
+  #  proxy_client_key: /etc/kcp-front-proxy/requestheader-client/tls/kcp/tls.key
+
+  # When running external virtual workspaces, kcp-front-proxy needs
+  # access to the CA that signed the VW's serving cert. Unless your
+  # VWs all use the kcp-server-issuer, you must mount all additional
+  # certificates yourself.
+  extraVolumes: []
+  # - name: example-vw-serving-cert
+  #   secret:
+  #     secretName: example-vw-serving-cert
+  #     items:
+  #       - key: ca.crt
+  #         path: ca.crt
+  extraVolumeMounts: []
+  # - name: example-vw-serving-cert
+  #   mountPath: /etc/example-vw-serving-cert
+  extraFlags: []
+cache:
+  enabled: false
+  image: ghcr.io/kcp-dev/kcp
+  tag: "main"
+  pullPolicy: Always
+  v: "4"
+  service:
+    annotations: {}
+    # set this to LoadBalancer if you want to publish kcp-front-proxy
+    # directly instead of going via Route/Ingress/Gateway resources.
+    type: ClusterIP
+  profiling:
+    enabled: false
+    port: 6060
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      # cpu: 1
+      memory: 1Gi
+  hostAliases:
+    enabled: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+externalCache:
+  enabled: false
+  cacheInternalHostname: ""
+
+oidc:
+  enabled: false
+  caSecretName: ""
+  # assuming you're using cert-manager, you want to mount the CA certificate
+  # directly and use its tls.crt key; if you instead mount a certificate that
+  # is _signed by_ the OIDC CA, then do not use its ca.crt key, as it is the
+  # absolute top root CA, the CA that actually signed the cert is one of the
+  # certs in the tls.crt chain. As you cannot say "use this Secret, but the
+  # second cert in the tls.crt key", it's easier to mount the CA cert secret.
+  caSecretKeyName: "tls.crt"
+audit:
+  enabled: false
+  volumeSize: 1Gi
+  volumeClassName: ""
+  policy:
+    dir: /etc/kcp/audit
+    fileName: audit-policy.yml
+    config: |
+      # Log all requests at the Metadata level.
+      apiVersion: audit.k8s.io/v1
+      kind: Policy
+      rules:
+      - level: Metadata
+  log:
+    maxAge: "10"
+    maxSize: "250"
+    maxBackup: "1"
+    dir: /var/audit
+certificates:
+  kcp:
+    pki: true
+    certs: true
+  frontproxy:
+    pki: true
+    certs: true
+  etcd:
+    pki: true
+    certs: true
+  cache:
+    pki: false
+    certs: false
+  secretTemplate:
+    enabled: false
+    annotations: {}
+    labels: {}
+  privateKeys:
+    algorithm: RSA
+    size: 2048
+  subject: {}
+  # add additional dns names that should be embedded into the kcp server certificate.
+  dnsNames:
+  - localhost
+letsEncrypt:
+  enabled: false
+  staging:
+    enabled: false
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: ""
+  production:
+    enabled: false
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: ""
+
+sharding:
+  enabled: false
+  isShard: false # set this to true for the all shards, false for the first (root) shard.
+  isRoot: true # set this to true for the first (root) shard, false for all other shards.
+  rootShardInternalHostname: "" # set this to the internal hostname of the root shard.

--- a/examples/sharded/README.md
+++ b/examples/sharded/README.md
@@ -1,0 +1,73 @@
+
+# Sharded example
+
+In this example, we use helm charts to deploy a sharded version of KCP.
+
+The final result from this example is a KCP cluster with 2 shards in 2 different
+namespaces, 1 frontend proxy and 1 cache server.
+
+### Prerequisites
+
+- Cert-manager installed in the cluster
+- Helm 3
+- reflector emberstack helm repository added for secret replication
+
+Namespace structure:
+```text
+kcp-certs - namespace for PKI infrastructure & certificates
+kcp-alpha - namespace for shard 1
+kcp-beta - namespace for shard 2
+kcp-proxy - namespace for frontend proxy
+kcp-cache - namespace for cache server
+```
+
+Having shards in different clusters is out of scope for this example. You need to
+create cross-cluster communication between shards yourself if you want to do that.
+You can use service mesh for that, or projects like [Submariner](https://submariner.io/).
+
+To generate certificates for KCP you need to create certificates in phases.
+Assuming you have a cluster with cert-manager installed, and you want to create
+certificates for 2 shards, you need to do the following:
+
+1. Deploy PKI infrastructure first:
+
+```bash
+helm upgrade --install --values ./kind-values-phase1.yaml --namespace kcp-certs --create-namespace kcp-certs ../../charts/certificates
+```
+
+In this example, we extend the `certificates` chart and enable the `secretTemplate`
+to replicate secrets into the `kcp-alpha` and `kcp-beta` and other namespaces
+where our shards and other components will be located
+
+2. Deploy certificates for shards:
+
+```bash
+helm upgrade --install --values ./kind-values-phase2-alpha.yaml --namespace kcp-certs --create-namespace kcp-alpha ../../charts/certificates
+helm upgrade --install --values ./kind-values-phase2-beta.yaml --namespace kcp-certs --create-namespace kcp-beta ../../charts/certificates
+helm upgrade --install --values ./kind-values-phase2-proxy.yaml --namespace kcp-certs --create-namespace kcp-proxy ../../charts/certificates
+helm upgrade --install --values ./kind-values-phase2-cache.yaml --namespace kcp-certs --create-namespace kcp-cache ../../charts/certificates
+```
+
+1. Deploy Cache server:
+
+```bash
+helm upgrade --install --values ./kind-values-phase3-cache.yaml --namespace kcp-cache --create-namespace kcp-cache ../../charts/cache
+```
+
+2. Deploy alpha root shard:
+
+```bash
+helm upgrade --install --values ./kind-values-phase3-alpha.yaml --namespace kcp-alpha --create-namespace kcp-alpha ../../charts/kcp-sharded
+```
+
+3. Deploy frontend proxy:
+
+```bash
+helm upgrade --install --values ./kind-values-phase3-proxy.yaml --namespace kcp-proxy --create-namespace kcp-proxy ../../charts/proxy
+```
+
+4. Deploy beta beta shard:
+
+```bash
+helm upgrade --install --values ./kind-values-phase3-beta.yaml --namespace kcp-beta --create-namespace kcp-beta ../../charts/kcp-sharded
+```

--- a/examples/sharded/kind-values-phase1.yaml
+++ b/examples/sharded/kind-values-phase1.yaml
@@ -1,0 +1,30 @@
+# Phase 1 creates PKI & CA infrastructure for all shards
+#
+# helm upgrade \
+#  --install \
+#  --values ./kind-values-phase1.yaml \
+#  --namespace kcp-certs \
+#  --create-namespace \
+#  kcp-certificates ./charts/certificates
+#
+certificates:
+  name: certs
+  kcp:
+    pki: true
+    certs: false
+  frontproxy:
+    pki: true
+    certs: false
+  etcd:
+    pki: true
+    certs: false
+  cache:
+    pki: true
+    certs: false
+  secretTemplate:
+    enabled: true
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"

--- a/examples/sharded/kind-values-phase2-alpha.yaml
+++ b/examples/sharded/kind-values-phase2-alpha.yaml
@@ -1,0 +1,38 @@
+# Phase 2 creates creates the KCP and KCP Front Proxy, etc certs for shard 1
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase2-alpha.yaml \
+#  --namespace kcp-certs \
+#  --create-namespace \
+#  alpha-certs ./charts/kcp
+#
+
+fullnameOverride: alpha
+externalHostname: "kcp.dev.local"
+certificates:
+  dnsNames:
+  - localhost
+  - alpha.kcp-alpha
+  - alpha.kcp-alpha.svc
+  - alpha.kcp-alpha.svc.cluster.local
+  name: certs
+  kcp:
+    pki: false
+    certs: true
+  frontproxy:
+    pki: false
+    certs: false
+  etcd:
+    pki: false
+    certs: true
+  cache:
+    pki: false
+    certs: false
+  secretTemplate:
+    enabled: true
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"

--- a/examples/sharded/kind-values-phase2-beta.yaml
+++ b/examples/sharded/kind-values-phase2-beta.yaml
@@ -1,0 +1,39 @@
+# Phase 2 creates creates the KCP and KCP Front Proxy, etc certs for shard 1
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase2-beta.yaml \
+#  --namespace kcp-certs \
+#  --create-namespace \
+#  beta-certs ./charts/kcp
+#
+
+fullnameOverride: beta
+# must be a valid DNS name for front proxy to work
+externalHostname: "kcp.dev.local"
+certificates:
+  dnsNames:
+  - localhost
+  - beta.kcp-beta
+  - beta.kcp-beta.svc
+  - beta.kcp-beta.svc.cluster.local
+  name: certs
+  kcp:
+    pki: false
+    certs: true
+  frontproxy:
+    pki: false
+    certs: false
+  etcd:
+    pki: false
+    certs: true
+  cache:
+    pki: false
+    certs: false
+  secretTemplate:
+    enabled: true
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"

--- a/examples/sharded/kind-values-phase2-cache.yaml
+++ b/examples/sharded/kind-values-phase2-cache.yaml
@@ -1,0 +1,39 @@
+# Phase 2 creates creates the KCP and KCP Front Proxy, etc certs for shard 1
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase2-beta.yaml \
+#  --namespace kcp-certs \
+#  --create-namespace \
+#  beta-certs ./charts/kcp
+#
+
+fullnameOverride: cache
+# must be a valid DNS name for front proxy to work
+externalHostname: "kcp.dev.local"
+certificates:
+  dnsNames:
+  - localhost
+  - cache-cache
+  - cache-cache.kcp-cache.svc
+  - cache-cache.kcp-cache.svc.cluster.local
+  name: certs
+  kcp:
+    pki: false
+    certs: false
+  frontproxy:
+    pki: false
+    certs: false
+  etcd:
+    pki: false
+    certs: false
+  cache:
+    pki: false
+    certs: true
+  secretTemplate:
+    enabled: true
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"

--- a/examples/sharded/kind-values-phase2-proxy.yaml
+++ b/examples/sharded/kind-values-phase2-proxy.yaml
@@ -1,0 +1,36 @@
+# Phase 2 creates creates the KCP and KCP Front Proxy, etc certs for shard 1
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase2-beta.yaml \
+#  --namespace kcp-certs \
+#  --create-namespace \
+#  beta-certs ./charts/kcp
+#
+
+fullnameOverride: proxy
+# must be a valid DNS name for front proxy to work
+externalHostname: "kcp.dev.local"
+certificates:
+  dnsNames:
+  - localhost
+  name: certs
+  kcp:
+    pki: false
+    certs: false
+  frontproxy:
+    pki: false
+    certs: true
+  etcd:
+    pki: false
+    certs: true
+  cache:
+    pki: false
+    certs: false
+  secretTemplate:
+    enabled: true
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "kcp-alpha,kcp-beta,kcp-proxy,kcp-cache"

--- a/examples/sharded/kind-values-phase3-alpha.yaml
+++ b/examples/sharded/kind-values-phase3-alpha.yaml
@@ -1,0 +1,37 @@
+# Phase 3 creates deployments for shard 1 (root)
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase3.yaml \
+#  --namespace kcp-alpha \
+#  --create-namespace \
+#  alpha ./charts/kcp
+#
+fullnameOverride: alpha
+externalHostname: "kcp.dev.local"
+etcd:
+  enabled: true
+kcp:
+  externalLogicalClusterAdminFlag: true
+  enabled: true
+  v: 8
+  tokenAuth:
+    enabled: true
+  tag: main
+  batteries:
+    - workspace-types
+    - metrics-viewer
+# hack to run without dns
+#  hostAliases:
+#    enabled: true
+#    values:
+#    - hostnames:
+#        - "kcp.dev.local"
+#      ip: "10.96.169.47"
+externalCache:
+  enabled: true
+  cacheInternalHostname: "cache-cache.kcp-cache.svc"
+sharding:
+  enabled: true
+  isShard: false
+  isRoot: true

--- a/examples/sharded/kind-values-phase3-beta.yaml
+++ b/examples/sharded/kind-values-phase3-beta.yaml
@@ -1,0 +1,37 @@
+# Phase 3 creates deployments for shard 1 (root)
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase3.yaml \
+#  --namespace kcp-alpha \
+#  --create-namespace \
+#  alpha ./charts/kcp
+#
+fullnameOverride: beta
+externalHostname: "kcp.dev.local"
+etcd:
+  enabled: true
+kcp:
+  enabled: true
+  v: 8
+  tokenAuth:
+    enabled: true
+  tag: main
+  batteries:
+    - workspace-types
+    - metrics-viewer
+# hack to run without dns
+#  hostAliases:
+#    enabled: true
+#    values:
+#    - hostnames:
+#        - "kcp.dev.local"
+#      ip: "10.96.169.47"
+externalCache:
+  enabled: true
+  cacheInternalHostname: "cache-cache.kcp-cache.svc"
+sharding:
+  enabled: true
+  isShard: true # set this to true for the all shards, false for the first (root) shard.
+  isRoot: false # set this to true for the first (root) shard, false for all other shards.
+  rootShardInternalHostname: "alpha.kcp-alpha.svc.cluster.local"

--- a/examples/sharded/kind-values-phase3-cache.yaml
+++ b/examples/sharded/kind-values-phase3-cache.yaml
@@ -1,0 +1,14 @@
+# Phase 3 creates deployments cache server
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase3.yaml \
+#  --namespace kcp-alpha \
+#  --create-namespace \
+#  alpha ./charts/kcp
+#
+fullnameOverride: cache
+externalHostname: "kcp.dev.local"
+cache:
+  enabled: true
+certificates:
+  name: certs

--- a/examples/sharded/kind-values-phase3-proxy.yaml
+++ b/examples/sharded/kind-values-phase3-proxy.yaml
@@ -1,0 +1,41 @@
+# Phase 4 creates deployments for shard 1
+#
+# helm upgrade \
+#  --install \
+#  --values ./hack/kind-values-phase3.yaml \
+#  --namespace kcp-alpha \
+#  --create-namespace \
+#  alpha ./charts/kcp
+#
+fullnameOverride: proxy
+externalHostname: "kcp.dev.local"
+etcd:
+  enabled: false
+kcp:
+  enabled: false
+kcpFrontProxy:
+  enabled: true
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+# hack to run without dns
+#  hostAliases:
+#    enabled: true
+#    values:
+#    - hostnames:
+#        - "kcp.dev.local"
+#      ip: "10.96.169.47"
+  tokenAuth:
+    enabled: true
+cache:
+  enabled: false
+certificates:
+  name: certs
+sharding:
+  enabled: false
+  isShard: false # set this to true for the all shards, false for the first (root) shard.
+  isRoot: true # set this to true for the first (root) shard, false for all other shards.
+  rootShardInternalHostname: "alpha.kcp-alpha.svc.cluster.local"
+


### PR DESCRIPTION
MVP to support split deployments and sharded model in helm
* add sub-charts for `cache`, `proxy`, `kcp-sharded`
* adds example how to run them in order to get shared deployment of kcp