### PR TITLE
✨ Update appVersion to 0.22.0 and eliminate server volume

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.4.4
-appVersion: "0.21.0"
+version: 0.5.0
+appVersion: "0.22.0"
 
 # optional metadata
 type: application

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -29,13 +29,15 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "front-proxy"
 spec:
-  replicas: 1
+  replicas: {{ .Values.kcpFrontProxy.replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "common.labels.selector" . | nindent 6 }}
       app.kubernetes.io/component: "front-proxy"
+  {{- with .Values.kcpFrontProxy.strategy }}
   strategy:
-    type: Recreate
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -1,20 +1,4 @@
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "kcp.fullname" . }}
-  labels:
-    {{- include "common.labels" . | nindent 4 }}
-    app.kubernetes.io/component: "server"
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.kcp.volumeSize }}
-  {{ with .Values.kcp.volumeClassName -}}storageClassName: {{ . }}{{- end }}
 {{- if .Values.audit.enabled }}
-
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -86,13 +70,15 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "server"
 spec:
-  replicas: 1
+  replicas: {{ .Values.kcp.replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "common.labels.selector" . | nindent 6 }}
       app.kubernetes.io/component: "server"
+  {{- with .Values.kcp.strategy }}
   strategy:
-    type: Recreate
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -328,8 +314,8 @@ spec:
           secret:
             secretName: {{ include "kcp.fullname" . }}-external-admin-kubeconfig-cert
         - name: kcp-config
-          persistentVolumeClaim:
-            claimName: {{ include "kcp.fullname" . }}
+          emptyDir:
+            sizeLimit: 50Mi
 
 ---
 apiVersion: v1

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -14,6 +14,9 @@ etcd:
   profiling:
     enabled: false
 kcp:
+  replicas: 1
+  strategy:
+    type: Recreate
   image: ghcr.io/kcp-dev/kcp
   # set this to override the image tag used for kcp (determined by chart appVersion by default).
   tag: ""
@@ -63,6 +66,9 @@ kcp:
     seccompProfile:
       type: RuntimeDefault
 kcpFrontProxy:
+  replicas: 1
+  strategy:
+    type: Recreate
   image: ghcr.io/kcp-dev/kcp
   # set this to override the image tag used for kcp-front-proxy (determined by chart appVersion by default).
   tag: ""


### PR DESCRIPTION
This PR bumps the chart to use kcp [v0.22.0](https://github.com/kcp-dev/kcp/releases/tag/v0.22.0), which felt like a minor version bump for the chart version, hence the bump to v0.5.0 as well.

In addition, this PR picks up on some goodies we added in the new kcp release:

- Since generating the `admin.kubeconfig` and associated files is now hidden in the `admin` battery (which is not enabled in  the batteries of this helm chart), we can replace the PVC with an emptyDir. The `kcp` binary still complains if `/etc/kcp/config` does not exist, but it creates nothing in that directory. So I put a dummy volume with a size limit of 50Mi in there.
- This unlocks scaling the server deployment past the single replica we have been stuck with (if you also enable leader election, which I plan to incorporate into the Helm chart as a follow up; also the current audit logging configuraton is problematic). So now we can make the replicas and deployment strategy configurable.