### PR TITLE
✨  Add support for monitoring kcp with prometheus-operator

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.6.0
+version: 0.6.1
 appVersion: "0.23.0"
 
 # optional metadata

--- a/charts/kcp/readme.md
+++ b/charts/kcp/readme.md
@@ -9,7 +9,9 @@ This Helm chart deploys KCP, including the following components:
 ## Dependencies
 
 * cert-manager
-* Openshift route
+* Openshift route (optional)
+* Ingress Controller (optional)
+* Prometheus Operator (optional, see [Monitoring](#monitoring))
 
 ## Options
 
@@ -27,3 +29,37 @@ Currently configurable options:
 * OIDC
 * Github user access to project
 * External hostname
+
+### Monitoring
+
+Each component (etcd, kcp-front-proxy and kcp-server) has a `.monitoring` key that allows configuring monitoring for those components. At the moment, only Prometheus Operator is supported and is required as a pre-requisite on the cluster.
+
+For all three, a `ServiceMonitor` resource can be created by setting `.[component].monitoring.serviceMonitor.enabled` to true. Monitoring for all components would therefore look like this:
+
+```yaml
+# enable ServiceMonitor for kcp-server.
+kcp:
+  monitoring:
+    serviceMonitor:
+      enabled: true
+
+# enable ServiceMonitor for kcp-front-proxy.
+kcpFrontProxy:
+  monitoring:
+    serviceMonitor:
+      enabled: true
+
+# enable ServiceMonitor for etcd.
+etcd:
+  monitoring:
+    serviceMonitor:
+      enabled: true
+```
+
+To collect metrics from these targets, a `Prometheus` instance targetting those `ServiceMonitors` is needed. A possible selector in the `Prometheus` spec is:
+
+```yaml
+serviceMonitorSelector:
+    matchLabels:
+      app.kubernetes.io/name: kcp
+```

--- a/charts/kcp/templates/_helpers.tpl
+++ b/charts/kcp/templates/_helpers.tpl
@@ -27,6 +27,14 @@ v{{- .Chart.AppVersion -}}
 {{- end -}}
 {{- end -}}
 
+{{- define "kcp.batteries" -}}
+{{- $batteries := .Values.kcp.batteries -}}
+{{- if .Values.kcp.monitoring.serviceMonitor.enabled -}}
+{{- $batteries = append $batteries "metrics-viewer" -}}
+{{- end -}}
+{{- $batteries | uniq | join "," -}}
+{{- end -}}
+
 {{- define "frontproxy.fullname" -}}
 {{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
 {{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}

--- a/charts/kcp/templates/etcd-servicemonitor.yaml
+++ b/charts/kcp/templates/etcd-servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.etcd.enabled .Values.etcd.monitoring.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "etcd.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  endpoints:
+  - interval: 30s
+    port: client
+    path: /metrics
+    scheme: https
+    tlsConfig:
+      serverName: {{ include "etcd.fullname" . }}
+      ca:
+        secret:
+          name: {{ include "etcd.fullname" . -}}-client-ca
+          key: tls.crt
+      cert:
+        secret:
+          name: {{ include "kcp.fullname" . -}}-etcd-client-cert
+          key: tls.crt
+      keySecret:
+        name: {{ include "kcp.fullname" . -}}-etcd-client-cert
+        key: tls.key
+  selector:
+    matchLabels:
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "etcd"
+{{- end }}

--- a/charts/kcp/templates/front-proxy-servicemonitor.yaml
+++ b/charts/kcp/templates/front-proxy-servicemonitor.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.kcpFrontProxy.monitoring.serviceMonitor.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "frontproxy.fullname" . }}-metrics
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  commonName: metrics-viewer
+  issuerRef:
+    name: {{ include "frontproxy.fullname" . }}-client-issuer
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  secretName: {{ include "frontproxy.fullname" . }}-metrics-cert
+  usages:
+  - client auth
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "frontproxy.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  endpoints:
+  - interval: 30s
+    port: "kcp-front-proxy"
+    path: /metrics
+    scheme: https
+    tlsConfig:
+      serverName: {{ .Values.externalHostname }}
+      ca:
+        secret:
+          name: {{ include "kcp.fullname" . }}-ca
+          key: tls.crt
+      cert:
+        secret:
+          name: {{ include "frontproxy.fullname" . }}-metrics-cert
+          key: tls.crt
+      keySecret:
+        name: {{ include "frontproxy.fullname" . }}-metrics-cert
+        key: tls.key
+  selector:
+    matchLabels:
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "front-proxy"
+{{- end }}

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -25,6 +25,7 @@ metadata:
   labels:
     {{- include "common.labels" . | nindent 4 }}
     app.kubernetes.io/component: "server"
+    kcp.io/service-monitor: kcp
 spec:
   ports:
     - protocol: TCP
@@ -164,9 +165,7 @@ spec:
             {{- if .Values.kcp.profiling.enabled }}
             - --profiler-address=0.0.0.0:{{- .Values.kcp.profiling.port -}}
             {{- end }}
-            {{- with .Values.kcp.batteries }}
-            - --batteries-included={{ join "," . }}
-            {{- end }}
+            - --batteries-included={{- include "kcp.batteries" . }}
             {{- range .Values.kcp.extraFlags }}
             - {{ . }}
             {{- end }}

--- a/charts/kcp/templates/server-servicemonitor.yaml
+++ b/charts/kcp/templates/server-servicemonitor.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.kcp.monitoring.serviceMonitor.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}-metrics
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  commonName: metrics-viewer
+  issuerRef:
+    name: {{ include "kcp.fullname" . }}-client-issuer
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  secretName: {{ include "kcp.fullname" . }}-metrics-cert
+  usages:
+  - client auth
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kcp.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  endpoints:
+  - interval: 30s
+    port: "kcp"
+    path: /clusters/root/metrics
+    scheme: https
+    tlsConfig:
+      serverName: {{ include "kcp.fullname" . }}
+      ca:
+        secret:
+          name: {{ include "kcp.fullname" . }}-ca
+          key: tls.crt
+      cert:
+        secret:
+          name: {{ include "kcp.fullname" . }}-metrics-cert
+          key: tls.crt
+      keySecret:
+        name: {{ include "kcp.fullname" . }}-metrics-cert
+        key: tls.key
+  selector:
+    matchLabels:
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "server"
+      kcp.io/service-monitor: kcp
+{{- end }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -9,10 +9,13 @@ etcd:
       memory: 2Gi
     limits:
       # cpu: 1
-     memory: 20Gi
+      memory: 20Gi
   volumeSize: 8Gi
   profiling:
     enabled: false
+  monitoring:
+    serviceMonitor:
+      enabled: false
 kcp:
   replicas: 1
   strategy:
@@ -65,6 +68,9 @@ kcp:
     fsGroup: 65532
     seccompProfile:
       type: RuntimeDefault
+  monitoring:
+    serviceMonitor:
+      enabled: false
 kcpFrontProxy:
   replicas: 1
   strategy:
@@ -114,6 +120,9 @@ kcpFrontProxy:
   securityContext:
     seccompProfile:
       type: RuntimeDefault
+  monitoring:
+    serviceMonitor:
+      enabled: false
 
   # The default virtual workspaces run in-process, but you can
   # extend the path mapping to include custom virtual workspaces


### PR DESCRIPTION
This adds three `ServiceMonitor` objects that can be enabled to monitor the components deployed by the `kcp` Helm chart: etcd, kcp-front-proxy and kcp(-server). 