### PR TITLE
Fix sharded charts to allow them to render successfully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.kubeconfig
 
 # output of hack/ci/validate-helm-resources.sh
-kcp-templated.yaml
+*-templated.yaml

--- a/charts/cache/Chart.yaml
+++ b/charts/cache/Chart.yaml
@@ -3,8 +3,8 @@ name: cache
 description: A cache server for prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.0.1
-appVersion: "0.21.0"
+version: 0.0.2
+appVersion: "0.22.0"
 
 # optional metadata
 type: application

--- a/charts/cache/templates/_helpers.tpl
+++ b/charts/cache/templates/_helpers.tpl
@@ -42,6 +42,14 @@ v{{- .Chart.AppVersion -}}
 {{- printf "%s-cache" $trimmedName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "cache.version" -}}
+{{- if .Values.cache.tag -}}
+{{- .Values.cache.tag -}}
+{{- else -}}
+v{{- .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "frontproxy.fullname" -}}
 {{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
 {{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}

--- a/charts/cache/templates/cache-deployment.yaml
+++ b/charts/cache/templates/cache-deployment.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       containers:
         - name: cache
-          image: {{ .Values.cache.image }}:{{- include "kcp.version" . }}
+          image: {{ .Values.cache.image }}:{{- include "cache.version" . }}
           imagePullPolicy: {{ .Values.cache.pullPolicy }}
           ports:
             - containerPort: 8012

--- a/charts/cache/values.yaml
+++ b/charts/cache/values.yaml
@@ -1,7 +1,9 @@
 externalHostname: ""
 cache:
-  enabled: false
-  image: {{ .Values.cache.image }}:{{- include "kcp.version" . }}
+  enabled: true
+  image: ghcr.io/kcp-dev/kcp
+  # set this to override the image tag used for kcp (determined by chart appVersion by default).
+  tag: ""
   pullPolicy: Always
   service:
     annotations: {}
@@ -21,3 +23,15 @@ cache:
   securityContext:
     seccompProfile:
       type: RuntimeDefault
+
+certificates:
+  name: certs
+  kcp:
+    pki: true
+    certs: false
+  etcd:
+    pki: true
+    certs: false
+  cache:
+    pki: true
+    certs: false

--- a/charts/certificates/Chart.yaml
+++ b/charts/certificates/Chart.yaml
@@ -3,8 +3,8 @@ name: certificates
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.0.1
-appVersion: "0.21.0"
+version: 0.0.2
+appVersion: "0.22.0"
 
 # optional metadata
 type: application

--- a/charts/certificates/values.yaml
+++ b/charts/certificates/values.yaml
@@ -2,6 +2,7 @@ fullnameOverride: alpha
 externalHostname: "kcp.dev.local"
 
 certificates:
+  name: certs
   kcp:
     pki: true
     certs: true

--- a/charts/proxy/Chart.yaml
+++ b/charts/proxy/Chart.yaml
@@ -3,8 +3,8 @@ name: proxy
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.0.1
-appVersion: "0.21.0"
+version: 0.0.2
+appVersion: "0.22.0"
 
 # optional metadata
 type: application

--- a/charts/proxy/templates/front-proxy-deployment.yaml
+++ b/charts/proxy/templates/front-proxy-deployment.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       containers:
         - name: kcp-front-proxy
-          image: "{{ .Values.kcpFrontProxy.image }}:{{- include "kcp.version" . }}"
+          image: "{{ .Values.kcpFrontProxy.image }}:{{- include "frontproxy.version" . }}"
           imagePullPolicy: {{ .Values.kcpFrontProxy.pullPolicy }}
           command: ["/kcp-front-proxy"]
           args:

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -1,68 +1,4 @@
 externalHostname: ""
-etcd:
-  enabled: true
-  image: quay.io/coreos/etcd
-  tag: v3.5.4
-  resources:
-    requests:
-      cpu: 500m
-      memory: 2Gi
-    limits:
-      # cpu: 1
-     memory: 20Gi
-  volumeSize: 8Gi
-  profiling:
-    enabled: false
-kcp:
-  enabled: true
-  image: ghcr.io/kcp-dev/kcp
-  # set this to override the image tag used for kcp (determined by chart appVersion by default).
-  tag: ""
-  pullPolicy: IfNotPresent
-  v: "3"
-  logicalClusterAdminFlag: true
-  externalLogicalClusterAdminFlag: true
-  # enabled "batteries" (see kcp start --help for available batteries).
-  batteries:
-    - workspace-types
-  resources:
-    requests:
-      memory: 512Mi
-      cpu: 100m
-    limits:
-      # cpu: 1
-      memory: 20Gi
-  volumeClassName: ""
-  etcd:
-    # set this if you are using external or embedded etcds.
-    serverAddress: ""
-    clientCertificate:
-      # set this to a cert-manager Issuer that knows how to
-      # issue client certificates for your external etcd if
-      # you are not using the etcd provided by this chart.
-      issuer: ""
-      commonName: root
-  volumeSize: 1Gi
-  extraFlags: []
-  profiling:
-    enabled: false
-    port: 6060
-  tokenAuth:
-    enabled: false
-    fileName: auth-token.csv
-    config: |
-        user-1-token,user-1,1111-1111-1111-1111,"team-1"
-        admin-token,admin,5555-5555-5555-5555,"system:kcp:admin"
-        system-token,system,6666-6666-6666-6666,"system:masters"
-  hostAliases:
-    enabled: false
-  homeWorkspaces:
-    enabled: false
-  securityContext:
-    # this matches the group id as set in the kcp Dockerfile.
-    fsGroup: 65532
-    seccompProfile:
-      type: RuntimeDefault
 kcpFrontProxy:
   enabled: true
   image: ghcr.io/kcp-dev/kcp
@@ -140,32 +76,6 @@ kcpFrontProxy:
   # - name: example-vw-serving-cert
   #   mountPath: /etc/example-vw-serving-cert
   extraFlags: []
-cache:
-  enabled: false
-  image: ghcr.io/kcp-dev/kcp
-  pullPolicy: Always
-  service:
-    annotations: {}
-    type: ClusterIP
-  profiling:
-    enabled: false
-    port: 6060
-  resources:
-    requests:
-      cpu: 100m
-      memory: 128Mi
-    limits:
-      # cpu: 1
-      memory: 1Gi
-  hostAliases:
-    enabled: false
-  securityContext:
-    seccompProfile:
-      type: RuntimeDefault
-externalCache:
-  enabled: false
-  cacheInternalHostname: ""
-
 oidc:
   enabled: false
   caSecretName: ""
@@ -176,25 +86,8 @@ oidc:
   # certs in the tls.crt chain. As you cannot say "use this Secret, but the
   # second cert in the tls.crt key", it's easier to mount the CA cert secret.
   caSecretKeyName: "tls.crt"
-audit:
-  enabled: false
-  volumeSize: 1Gi
-  volumeClassName: ""
-  policy:
-    dir: /etc/kcp/audit
-    fileName: audit-policy.yml
-    config: |
-      # Log all requests at the Metadata level.
-      apiVersion: audit.k8s.io/v1
-      kind: Policy
-      rules:
-      - level: Metadata
-  log:
-    maxAge: "10"
-    maxSize: "250"
-    maxBackup: "1"
-    dir: /var/audit
 certificates:
+  name: certs
   kcp:
     pki: true
     certs: true

--- a/charts/shard/Chart.yaml
+++ b/charts/shard/Chart.yaml
@@ -3,8 +3,8 @@ name: shard
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.0.1
-appVersion: "0.21.0"
+version: 0.0.2
+appVersion: "0.22.0"
 
 # optional metadata
 type: application

--- a/charts/shard/values.yaml
+++ b/charts/shard/values.yaml
@@ -114,6 +114,13 @@ caBundle:
 
 cache:
   enabled: false
+externalCache:
+  enabled: false
 
 certificates:
   name: certs
+
+sharding:
+  enabled: false
+  isRoot: true # set this to true for the first (root) shard, false for all other shards.
+  rootShardInternalHostname: "" # set this to the internal hostname of the root shard.

--- a/hack/ci/render-helm-charts.sh
+++ b/hack/ci/render-helm-charts.sh
@@ -14,19 +14,26 @@ if ! [ -x "$(command -v kubeconform)" ]; then
     exit 1
 fi
 
-helm template \
-  --debug \
-  --set=externalHostname=ci.kcp.io \
-  kcp charts/kcp/ | tee kcp-templated.yaml
+for dir in ./charts/*/; do
+  dir=${dir%*/}
+  chart=${dir##*/}
 
-echo "---"
+  helm template \
+    --debug \
+    --set=externalHostname=ci.kcp.io \
+    kcp ./charts/${chart}/ | tee ${chart}-templated.yaml
 
-# run kubeconform on template output to validate Kubernetes resources.
-# the external schema-location allows us to validate resources for
-# common CRDs (e.g. cert-manager resources).
-kubeconform \
-  -schema-location default \
-  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
-  -strict \
-  -summary \
-  kcp-templated.yaml
+  echo "---"
+
+  # run kubeconform on template output to validate Kubernetes resources.
+  # the external schema-location allows us to validate resources for
+  # common CRDs (e.g. cert-manager resources).
+  kubeconform \
+    -schema-location default \
+    -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+    -strict \
+    -summary \
+    ${chart}-templated.yaml
+
+  rm ${chart}-templated.yaml
+done


### PR DESCRIPTION
This is probably not 100% cleaned up yet, but I added the new charts to the chart rendering script we run in CI to validate them. Publishing the last PR failed (see https://github.com/kcp-dev/helm-charts/commit/6c14e542c6d5ccd49887508e5eeffa8748b9af6f), so we need additional validation.

I found a couple of issues and missing fields in `values.yaml` of multiple charts that are expected to be there by the templates, so I've added them.