### PR TITLE
✨  Bump kcp version to 0.23.0

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.5.0
-appVersion: "0.22.0"
+version: 0.6.0
+appVersion: "0.23.0"
 
 # optional metadata
 type: application


### PR DESCRIPTION
Housekeeping for the Helm chart, we have released kcp [0.23.0](https://github.com/kcp-dev/kcp/releases/tag/v0.23.0) a while ago so this bumps the Helm chart to use that version. It's a prerequisite for #82 as that requires the metrics-viewer battery fix in kcp.

/cc @xrstf @mjudeikis 