### PR TITLE
server-deployment: add .Values.externalPort to customize EXTERNAL_PORT

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.6.1
+version: 0.6.2
 appVersion: "0.23.0"
 
 # optional metadata

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -173,7 +173,7 @@ spec:
             - name: EXTERNAL_HOSTNAME
               value: {{ required "A valid external hostname is required" .Values.externalHostname }}
             - name: EXTERNAL_PORT
-              value: "{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}"
+              value: "8443"
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -173,7 +173,7 @@ spec:
             - name: EXTERNAL_HOSTNAME
               value: {{ required "A valid external hostname is required" .Values.externalHostname }}
             - name: EXTERNAL_PORT
-              value: "8443"
+              value: "{{ if eq .Values.externalPort "" }}{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}{{ else }}{{ .Values.externalPort }}{{- end }}"
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:

--- a/charts/kcp/templates/server-kubeconfigs.yaml
+++ b/charts/kcp/templates/server-kubeconfigs.yaml
@@ -48,7 +48,7 @@ stringData:
           # this references the CA certificate that signed the kcp-front-proxy's certificate
           # (kcp-server-issuer by default, but could also be any other, external CA)
           certificate-authority: /etc/kcp/tls/ca/tls.crt
-          server: "https://{{ .Values.externalHostname }}:{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}"
+          server: "https://{{ .Values.externalHostname }}:{{ if eq .Values.externalPort "" }}{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}{{ else }}{{ .Values.externalPort }}{{- end }}"
     contexts:
       - name: external-logical-cluster
         context:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -1,4 +1,5 @@
 externalHostname: ""
+externalPort: "" # defaults to 8443 for .Values.kcpFrontProxy.service.type "LoadBalancer", 443 otherwise.
 etcd:
   enabled: true
   image: quay.io/coreos/etcd


### PR DESCRIPTION
Before this PR, the external port of the kcp server is set to 8443 for a `LoadBalancer` service type and 443 otherwise. The later is the case where an ingress is expected to be in-front of kcp. But when the actual usecase is to talk to the frontproxy directly via the service, this logic is wrong. Adding `.Values.externalPort` allows the customize the port, overriding upper logic.