### PR TITLE
Add PodDisruptionBudgets for all KCP components

### DIFF
--- a/charts/kcp/templates/etcd-pdb.yaml
+++ b/charts/kcp/templates/etcd-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.etcd.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "etcd.fullname" . }}
+  labels:
+    {{- include "common.labels.selector" . | nindent 4 }}
+    app.kubernetes.io/component: "etcd"
+spec:
+  maxUnavailable: {{ .Values.etcd.podDisruptionBudget.maxUnavailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "common.labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: "etcd"
+{{- end }}

--- a/charts/kcp/templates/front-proxy-pdb.yaml
+++ b/charts/kcp/templates/front-proxy-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.kcpFrontProxy.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "frontproxy.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "front-proxy"
+spec:
+  minAvailable: {{ .Values.kcpFrontProxy.podDisruptionBudget.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "common.labels" . | nindent 6 }}
+      app.kubernetes.io/component: "front-proxy"
+{{- end }}

--- a/charts/kcp/templates/server-pdb.yaml
+++ b/charts/kcp/templates/server-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.kcp.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kcp.fullname" . }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  minAvailable: {{ .Values.kcp.podDisruptionBudget.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "common.labels" . | nindent 6 }}
+      app.kubernetes.io/component: "server"
+{{- end }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -17,6 +17,9 @@ etcd:
   monitoring:
     serviceMonitor:
       enabled: false
+  podDisruptionBudget:
+    enabled: false
+    maxUnavailable: 1
 kcp:
   replicas: 1
   strategy:
@@ -72,6 +75,9 @@ kcp:
   monitoring:
     serviceMonitor:
       enabled: false
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
 kcpFrontProxy:
   replicas: 1
   strategy:
@@ -124,7 +130,9 @@ kcpFrontProxy:
   monitoring:
     serviceMonitor:
       enabled: false
-
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
   # The default virtual workspaces run in-process, but you can
   # extend the path mapping to include custom virtual workspaces
   # in the front-proxy's routing.

--- a/hack/kind-setup.sh
+++ b/hack/kind-setup.sh
@@ -56,7 +56,7 @@ kubectl --context "$KUBECTL_CONTEXT" --namespace ingress-nginx rollout status de
 # among the things that the kcp helm chart will do.
 
 export KCP_TAG="${KCP_TAG:-latest}"
-echo "Installing KCP version $KCP_TAG…"
+echo "Installing KCP version ${KCP_TAG}…"
 
 helm upgrade \
   --install \
@@ -72,7 +72,7 @@ echo "Generating KCP admin kubeconfig…"
 
 hostname="$(yq '.externalHostname' hack/kind-values.yaml)"
 
-echo "Checking /etc/hosts for $hostname…"
+echo "Checking /etc/hosts for ${hostname}…"
 if ! grep -q "$hostname" /etc/hosts; then
   echo "127.0.0.1 $hostname" | sudo tee -a /etc/hosts
 else


### PR DESCRIPTION
This PR adds an optional PodDisruptionBudget for KCP, front proxy, and etcd. This ensures that each component remains available during node draining/upgrades.

KCP server - if enabled, defaults to minAvailable = 1 
front proxy - same as KCP server. if enabled, defaults to minAvailable = 1 
etcd - if enabled, defaults to maxUnavailable = 1

Tested locally via updating the `./hack/kind-values.yaml`
```
diff --git a/hack/kind-values.yaml b/hack/kind-values.yaml
index b14c13f..0b8358c 100644
--- a/hack/kind-values.yaml
+++ b/hack/kind-values.yaml
@@ -1,14 +1,22 @@
 externalHostname: "kcp.dev.local"
 etcd:
-  enabled: false
+  enabled: true
+  podDisruptionBudget:
+    enabled: true
 kcp:
+  replicas: 2
   # tag is set via --set flag to make it more dynamic for testing purposes
   volumeClassName: "standard"
   tokenAuth:
     enabled: true
   etcd:
-    serverAddress: embedded
+    serverAddress: ""
+  podDisruptionBudget:
+    enabled: true
 kcpFrontProxy:
+  replicas: 2
+  podDisruptionBudget:
+    enabled: true
   # tag is set via --set flag to make it more dynamic for testing purposes
   openshiftRoute:
     enabled: false
```

`k get poddisruptionbudgets -A`
```
NAMESPACE   NAME              MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
kcp         kcp               1               N/A               1                     6m44s
kcp         kcp-etcd          N/A             1                 1                     6m44s
kcp         kcp-front-proxy   1               N/A               1                     6m44s
```