### PR TITLE
Rework kind setup by removing Ingress and embedded etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,47 +183,26 @@ We can now add these credentials to the `admin.kubeconfig` and access kcp:
 ## Install to kind cluster (for development)
 
 There is a helper script to install kcp to a [kind](https://github.com/kubernetes-sigs/kind) cluster.
-It will install cert-manager, nginx-ingress and kcp. Kind cluster binds to host ports 6440 (for kind container port 80)
-and 6443 (for kind container port 443) for ingress. Ingress is emulated using host entries in `/etc/hosts`.
-This particular configuration is useful for development and testing, but will not work with LetsEncrypt.
+It will install cert-manager and kcp. The `kind` cluster binds to host port 8443 for exposing kcp.
+This particular configuration is useful for development and testing, but will not work with Let's Encrypt.
 
     ./hack/kind-setup.sh
 
 Pre-requisites established by that script:
 
 * `kind` executable installed at `/usr/local/bin/kind`
-* Kind cluster named `kcp`
-* Cert-manager installer and running
-* Ingress installed
-* `/etc/hosts entry` for `kcp.dev.local` pointing to `127.0.0.1`
+* kind cluster named `kcp`
+* [cert-manager](https://cert-manager.io/) installed on the cluster
+* `/etc/hosts` entry for `kcp.dev.local` pointing to `127.0.0.1`
 
-That script will do this helm install:
+The script will then install kcp the following way:
 
     helm upgrade --install my-kcp ./charts/kcp/ \
       --values ./hack/kind-values.yaml \
       --namespace kcp \
       --create-namespace
 
-Where `hack/kind-values.yaml` is:
-
-```yaml
-externalHostname: "kcp.dev.local"
-kcp:
-  volumeClassName: "standard"
-  tokenAuth:
-    enabled: true
-kcpFrontProxy:
-  openshiftRoute:
-    enabled: false
-  ingress:
-    enabled: true
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
-      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-  certificate:
-    issuerSpec:
-      selfSigned: {}
-```
+See [hack/kind-values.yaml](./hack/kind-values.yaml) for the values passed to the Helm chart.
 
 # Known issues
 

--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.6.2
+version: 0.6.3
 appVersion: "0.23.0"
 
 # optional metadata

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -10,12 +10,18 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.kcpFrontProxy.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
   type: {{ .Values.kcpFrontProxy.service.type }}
   ports:
     - protocol: TCP
       name: kcp-front-proxy
       port: 8443
       targetPort: 8443
+      {{- with .Values.kcpFrontProxy.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "common.labels.selector" . | nindent 4 }}
     app.kubernetes.io/component: "front-proxy"

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -107,6 +107,12 @@ kcpFrontProxy:
     # set this to LoadBalancer if you want to publish kcp-front-proxy
     # directly instead of going via Route/Ingress/Gateway resources.
     type: ClusterIP
+    # set this if you want to control the assigned node ports of the
+    # kcp-front-proxy Service (only applies if type is "NodePort" or "LoadBalancer")
+    nodePort: ""
+    # set this if you want to control the assigned service IP for the kcp-front-proxy
+    # service.
+    clusterIP: ""
   # set this if you want kcp-front-proxy to use a specific certificate issuer
   # (e.g. the Let's Encrypt ones in this chart).
   # certificateIssuer:

--- a/hack/generate-admin-kubeconfig.sh
+++ b/hack/generate-admin-kubeconfig.sh
@@ -12,7 +12,7 @@ kind: Config
 clusters:
   - cluster:
       insecure-skip-tls-verify: true
-      server: "https://$hostname:6443/clusters/root"
+      server: "https://${hostname}:8443/clusters/root"
     name: kind-kcp
 contexts:
   - context:

--- a/hack/kind-setup.sh
+++ b/hack/kind-setup.sh
@@ -28,11 +28,6 @@ else
   echo "Cluster $CLUSTER_NAME already exists."
 fi
 
-echo "Installing ingress…"
-
-kubectl apply --filename https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-kubectl label nodes "$CLUSTER_NAME-control-plane" "node-role.kubernetes.io/control-plane-"
-
 echo "Installing cert-manager…"
 
 helm repo add jetstack https://charts.jetstack.io
@@ -47,22 +42,15 @@ helm upgrade \
   --version v1.13.0 \
   cert-manager jetstack/cert-manager
 
-# wait till now before checking nginx so that it and cert-manager can boot up in parallel
-echo "Waiting for the ingress controller to become ready…"
-kubectl --context "$KUBECTL_CONTEXT" --namespace ingress-nginx rollout status deployment/ingress-nginx-controller --timeout 5m
-
 # Installing cert-manager will end with a message saying that the next step
 # is to create some Issuers and/or ClusterIssuers.  That is indeed
 # among the things that the kcp helm chart will do.
 
-export KCP_TAG="${KCP_TAG:-latest}"
-echo "Installing KCP version ${KCP_TAG}…"
+echo "Installing KCP…"
 
 helm upgrade \
   --install \
   --values ./hack/kind-values.yaml \
-  --set "kcp.tag=$KCP_TAG" \
-  --set "kcpFrontProxy.tag=$KCP_TAG" \
   --namespace kcp \
   --create-namespace \
   kcp ./charts/kcp

--- a/hack/kind-values.yaml
+++ b/hack/kind-values.yaml
@@ -1,19 +1,26 @@
 externalHostname: "kcp.dev.local"
+externalPort: "8443"
 etcd:
-  enabled: false
+  resources:
+    requests:
+      memory: 256Mi
+certificates:
+  dnsNames:
+    - localhost
+    - kcp.dev.local
 kcp:
   # tag is set via --set flag to make it more dynamic for testing purposes
   volumeClassName: "standard"
   tokenAuth:
     enabled: true
-  etcd:
-    serverAddress: embedded
-kcpFrontProxy:
-  # tag is set via --set flag to make it more dynamic for testing purposes
-  openshiftRoute:
-    enabled: false
-  ingress:
+  hostAliases:
     enabled: true
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
-      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    values:
+      - ip: "10.96.0.100"
+        hostnames:
+          - "kcp.dev.local"
+kcpFrontProxy:
+  service:
+    type: NodePort
+    nodePort: 31443
+    clusterIP: "10.96.0.100"

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -19,9 +19,6 @@ nodes:
           kubeletExtraArgs:
             node-labels: "ingress-ready=true"
     extraPortMappings:
-      - containerPort: 443
-        hostPort: 6443
-        protocol: TCP
-      - containerPort: 80
-        hostPort: 6440
+      - containerPort: 31443
+        hostPort: 8443
         protocol: TCP


### PR DESCRIPTION
This PR is a pretty big refresh to the kind setup because I was discussing it with an interested party and we just couldn't get the setup to work properly. I assume it has been broken in many ways for a while.

The changes in this PR are:

- Eliminate usage of an Ingress. If we are going to have a node port exposure via nginx-ingress-controller, might as well expose kcp directly. This switches the `kcp-front-proxy` Service to be of type `NodePort`.
- Make the `kcp-front-proxy` Service more configurable to pre-allocate a service IP and a specific node port, so we can hack in DNS entries (on the kcp Pod side) and node port forwards (on the `kind` side) pointing to the front proxy.
  - Subsequently, this PR sets up a host alias in the kcp pod to make sure that traffic to the external name gets routed to the kcp-front-proxy Service.
- Get rid of using the `latest` tag. This is a setup that new users will end up with to try out kcp, there is no reason to expose them to development versions.
- Stop using embedded etcd. It's broken (since #81).

Please give this a spin on your system before approving it, but for my kind setup it works without issues as far as I can say.