### PR TITLE
Bump kcp AppVersion to 0.24.0

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.6.3
-appVersion: "0.23.0"
+version: 0.7.0
+appVersion: "0.24.0"
 
 # optional metadata
 type: application


### PR DESCRIPTION
We cut kcp [0.24.0](https://github.com/kcp-dev/kcp/releases/tag/v0.24.0) in April but never updated the Helm chart. Here's the PR to do that.