### PR TITLE
Update `pull-helm-charts-render` presubmit to `build:1.22.5-1` image

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -5,7 +5,7 @@ presubmits:
     clone_uri: "https://github.com/kcp-dev/helm-charts"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.9-3
+        - image: ghcr.io/kcp-dev/infra/build:1.22.5-1
           command:
             - hack/ci/render-helm-charts.sh
           resources:


### PR DESCRIPTION
We are running a quite old build image in this presubmit, this updates it to the latest available `ghcr.io/kcp-dev/infra/build` image. It includes an update to Helm 3.15.3.