### PR TITLE
Don't make use of /bin/sh in etcd images & update etcd version

### DIFF
--- a/charts/kcp/templates/etcd-statefulset.yaml
+++ b/charts/kcp/templates/etcd-statefulset.yaml
@@ -42,33 +42,37 @@ spec:
         - name: etcd
           image: {{ .Values.etcd.image }}:{{ .Values.etcd.tag }}
           command:
-            - /bin/sh
-            - -c
-            - |
-              PEERS="{{ include "etcd.fullname" . }}-0=https://{{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-1=https://{{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-2=https://{{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}:2380"
-              exec etcd --name ${HOSTNAME} \
-                --listen-peer-urls https://0.0.0.0:2380 \
-                --initial-advertise-peer-urls https://${HOSTNAME}:2380 \
-                --listen-client-urls https://0.0.0.0:2379 \
-                --advertise-client-urls https://${HOSTNAME}:2379 \
-                --initial-cluster-token etcd-cluster-1 \
-                --initial-cluster ${PEERS} \
-                --initial-cluster-state new \
-                --auto-compaction-mode=periodic \
-                --auto-compaction-retention=5m \
-                --data-dir /var/run/etcd/default.etcd \
-                --peer-client-cert-auth=true \
-                --peer-cert-file=/etc/etcd/tls/peer/tls.crt \
-                --peer-key-file=/etc/etcd/tls/peer/tls.key \
-                --peer-trusted-ca-file=/etc/etcd/tls/peer-ca/tls.crt \
-                --client-cert-auth=true \
-                --cert-file=/etc/etcd/tls/server/tls.crt \
-                --key-file=/etc/etcd/tls/server/tls.key \
-                --trusted-ca-file=/etc/etcd/tls/client-ca/tls.crt \
-                {{- if .Values.etcd.profiling.enabled }}
-                --enable-pprof=true \
-                {{- end }}
-                --snapshot-count=5000
+          - etcd
+          - --name=$(HOSTNAME)
+          - --listen-peer-urls=https://0.0.0.0:2380
+          - --initial-advertise-peer-urls=https://$(HOSTNAME):2380
+          - --listen-client-urls=https://0.0.0.0:2379
+          - --advertise-client-urls=https://$(HOSTNAME):2379
+          - --initial-cluster-token=etcd-cluster-1
+          - --initial-cluster=$(PEERS)
+          - --initial-cluster-state=new
+          - --auto-compaction-mode=periodic
+          - --auto-compaction-retention=5m
+          - --data-dir=/var/run/etcd/default.etcd
+          - --peer-client-cert-auth=true
+          - --peer-cert-file=/etc/etcd/tls/peer/tls.crt
+          - --peer-key-file=/etc/etcd/tls/peer/tls.key
+          - --peer-trusted-ca-file=/etc/etcd/tls/peer-ca/tls.crt
+          - --client-cert-auth=true
+          - --cert-file=/etc/etcd/tls/server/tls.crt
+          - --key-file=/etc/etcd/tls/server/tls.key
+          - --trusted-ca-file=/etc/etcd/tls/client-ca/tls.crt
+          {{- if .Values.etcd.profiling.enabled }}
+          - --enable-pprof=true
+          {{- end }}
+          - --snapshot-count=5000
+          env:
+          - name: PEERS
+            value: "{{ include "etcd.fullname" . }}-0=https://{{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-1=https://{{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-2=https://{{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}:2380"
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           ports:
             - containerPort: 2379
               name: client

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -3,7 +3,7 @@ externalPort: "" # defaults to 8443 for .Values.kcpFrontProxy.service.type "Load
 etcd:
   enabled: true
   image: quay.io/coreos/etcd
-  tag: v3.5.4
+  tag: v3.5.15
   resources:
     requests:
       cpu: 500m

--- a/charts/shard/templates/etcd-statefulset.yaml
+++ b/charts/shard/templates/etcd-statefulset.yaml
@@ -42,33 +42,37 @@ spec:
         - name: etcd
           image: {{ .Values.etcd.image }}:{{ .Values.etcd.tag }}
           command:
-            - /bin/sh
-            - -c
-            - |
-              PEERS="{{ include "etcd.fullname" . }}-0=https://{{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-1=https://{{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-2=https://{{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}:2380"
-              exec etcd --name ${HOSTNAME} \
-                --listen-peer-urls https://0.0.0.0:2380 \
-                --initial-advertise-peer-urls https://${HOSTNAME}:2380 \
-                --listen-client-urls https://0.0.0.0:2379 \
-                --advertise-client-urls https://${HOSTNAME}:2379 \
-                --initial-cluster-token etcd-cluster-1 \
-                --initial-cluster ${PEERS} \
-                --initial-cluster-state new \
-                --auto-compaction-mode=periodic \
-                --auto-compaction-retention=5m \
-                --data-dir /var/run/etcd/default.etcd \
-                --peer-client-cert-auth=true \
-                --peer-cert-file=/etc/etcd/tls/peer/tls.crt \
-                --peer-key-file=/etc/etcd/tls/peer/tls.key \
-                --peer-trusted-ca-file=/etc/etcd/tls/peer-ca/tls.crt \
-                --client-cert-auth=true \
-                --cert-file=/etc/etcd/tls/server/tls.crt \
-                --key-file=/etc/etcd/tls/server/tls.key \
-                --trusted-ca-file=/etc/etcd/tls/client-ca/tls.crt \
-                {{- if .Values.etcd.profiling.enabled }}
-                --enable-pprof=true \
-                {{- end }}
-                --snapshot-count=5000
+          - etcd
+          - --name=$(HOSTNAME)
+          - --listen-peer-urls=https://0.0.0.0:2380
+          - --initial-advertise-peer-urls=https://$(HOSTNAME):2380
+          - --listen-client-urls=https://0.0.0.0:2379
+          - --advertise-client-urls=https://$(HOSTNAME):2379
+          - --initial-cluster-token=etcd-cluster-1
+          - --initial-cluster=$(PEERS)
+          - --initial-cluster-state=new
+          - --auto-compaction-mode=periodic
+          - --auto-compaction-retention=5m
+          - --data-dir=/var/run/etcd/default.etcd
+          - --peer-client-cert-auth=true
+          - --peer-cert-file=/etc/etcd/tls/peer/tls.crt
+          - --peer-key-file=/etc/etcd/tls/peer/tls.key
+          - --peer-trusted-ca-file=/etc/etcd/tls/peer-ca/tls.crt
+          - --client-cert-auth=true
+          - --cert-file=/etc/etcd/tls/server/tls.crt
+          - --key-file=/etc/etcd/tls/server/tls.key
+          - --trusted-ca-file=/etc/etcd/tls/client-ca/tls.crt
+          {{- if .Values.etcd.profiling.enabled }}
+          - --enable-pprof=true
+          {{- end }}
+          - --snapshot-count=5000
+          env:
+          - name: PEERS
+            value: "{{ include "etcd.fullname" . }}-0=https://{{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-1=https://{{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}:2380,{{ include "etcd.fullname" . }}-2=https://{{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}:2380"
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           ports:
             - containerPort: 2379
               name: client


### PR DESCRIPTION
Fixes: #72 

@mjudeikis do you want me to update the default etcd Helm value as well?
I verified the CLI flags to etcd stayed the same before and after, and that a StatefulSet upgrade to etcd version `v3.5.15` in Helm values worked 👍 

cc @sttts 