### PR TITLE
kcp: update to kcp release 0.25.0

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.7.0
-appVersion: "0.24.0"
+version: 0.8.0
+appVersion: "0.25.0"
 
 # optional metadata
 type: application


### PR DESCRIPTION
We just released kcp 0.25.0 (https://github.com/kcp-dev/kcp/releases/tag/v0.25.0) so this bumps the Helm chart appropriately. 