### PR TITLE
fix front-proxy Ingress' backend service

### DIFF
--- a/charts/kcp/templates/front-proxy-ingress.yaml
+++ b/charts/kcp/templates/front-proxy-ingress.yaml
@@ -46,7 +46,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: kcp-front-proxy
+                name: {{ include "frontproxy.fullname" . }}
                 port:
                   number: 8443
 {{- end }}


### PR DESCRIPTION
I believe the `backend.service.name` targeted by the Ingress for the front-proxy should use the front-proxy's templated name, instead of having "kcp-front-proxy" hardcoded.