### PR TITLE
Remove support for embedded etcd in Chart

### DIFF
--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -111,11 +111,9 @@ spec:
             {{- else if .Values.etcd.enabled }}
             - --etcd-servers=https://{{ include "etcd.fullname" . }}:2379
             {{- end }}
-            {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}
             - --etcd-keyfile=/etc/kcp/tls/etcd-client/tls.key
             - --etcd-certfile=/etc/kcp/tls/etcd-client/tls.crt
             - --etcd-cafile=/etc/etcd/tls/client-ca/tls.crt
-            {{- end }}
             - --client-ca-file=/etc/kcp/tls/client-ca/tls.crt
             - --tls-private-key-file=/etc/kcp/tls/server/tls.key
             - --tls-cert-file=/etc/kcp/tls/server/tls.crt
@@ -209,12 +207,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}
             - name: kcp-etcd-client-cert
               mountPath: /etc/kcp/tls/etcd-client
             - name: etcd-client-ca
               mountPath: /etc/etcd/tls/client-ca
-            {{- end }}
             - name: kcp-ca
               mountPath: /etc/kcp/tls/ca
             - name: kcp-cert
@@ -254,14 +250,12 @@ spec:
             - name: kcp-config
               mountPath: /etc/kcp/config
       volumes:
-        {{- if ne .Values.kcp.etcd.serverAddress "embedded" }}
         - name: kcp-etcd-client-cert
           secret:
             secretName: {{ include "kcp.fullname" . }}-etcd-client-cert
         - name: etcd-client-ca
           secret:
             secretName: {{ include "etcd.fullname" . }}-client-ca
-        {{- end }}
         - name: kcp-ca
           secret:
             secretName: {{ include "kcp.fullname" . }}-ca

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -44,7 +44,7 @@ kcp:
       memory: 20Gi
   volumeClassName: ""
   etcd:
-    # set this if you are using external or embedded etcds.
+    # set this if you are using external etcds. Do not set this to "embedded", it is not supported.
     serverAddress: ""
     clientCertificate:
       # set this to a cert-manager Issuer that knows how to


### PR DESCRIPTION
Support for running with embedded etcd (a mode implemented in kcp for local development) has been added in #51. Unfortunately, it has been broken since #81 when I started eliminating the use of kcp's root directory for anything. A follow-up to that is currently in review at https://github.com/kcp-dev/kcp/pull/3158.

As per the [thread](https://kubernetes.slack.com/archives/C021U8WSAFK/p1720507955236309) on Slack, it seems we are in agreement that this shouldn't be supported anymore. It seems that no adopter is actually using it (since it's broken since beginning of the year) and it creates severe headache to running kcp as a Deployment.