### PR TITLE
Add X-Remote-Extra- headers prefix configuration

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.8.0
+version: 0.8.1
 appVersion: "0.25.0"
 
 # optional metadata

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -132,6 +132,7 @@ spec:
             - --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client-ca/tls.crt
             - --requestheader-username-headers=X-Remote-User
             - --requestheader-group-headers=X-Remote-Group
+            - --requestheader-extra-headers-prefix=X-Remote-Extra-
             - --root-directory=/etc/kcp/config
             - --shard-virtual-workspace-ca-file=/etc/kcp/tls/ca/tls.crt
             - --shard-base-url=https://{{ include "kcp.fullname" . }}:6443


### PR DESCRIPTION
Fixes https://github.com/kcp-dev/helm-charts/issues/103.

kcp-front-proxy sets the `X-Remote-` headers after validating a ServiceAccount token, but the kcp server wasn't accepting that header. This fixes that oversight, so now all extra auth information parsed by the front-proxy should be accepted by the kcp server.

Some of the information lost in the process was the clusterName that the ServiceAccount is coming from, which resulted in having to explicitly grant them access via RBAC if the ServiceAccount token was used against the front-proxy (but not against the server directly).