### PR TITLE
Use appropriate CA cert to reach the front-proxy

### DIFF
--- a/charts/kcp/templates/front-proxy-servicemonitor.yaml
+++ b/charts/kcp/templates/front-proxy-servicemonitor.yaml
@@ -32,10 +32,17 @@ spec:
     scheme: https
     tlsConfig:
       serverName: {{ .Values.externalHostname }}
+      {{- if not .Values.kcpFrontProxy.certificateIssuer }}
       ca:
         secret:
           name: {{ include "kcp.fullname" . }}-ca
           key: tls.crt
+      {{- else if .Values.kcpFrontProxy.certificateIssuer.secret }}
+      ca:
+        secret:
+          name: {{ required "kcpFrontProxy.certificateIssuer.secret.name is required" .Values.kcpFrontProxy.certificateIssuer.secret.name }}
+          key: {{ required "kcpFrontProxy.certificateIssuer.secret.key is required" .Values.kcpFrontProxy.certificateIssuer.secret.key }}
+      {{- end }}
       cert:
         secret:
           name: {{ include "frontproxy.fullname" . }}-metrics-cert

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -217,6 +217,10 @@ spec:
             {{- end }}
             - name: kcp-ca
               mountPath: /etc/kcp/tls/ca
+            {{- if and .Values.kcpFrontProxy.certificateIssuer .Values.kcpFrontProxy.certificateIssuer.secret }}
+            - name: kcp-front-proxy-ca
+              mountPath: /etc/kcp-front-proxy/tls/ca
+            {{- end}}
             - name: kcp-cert
               mountPath: /etc/kcp/tls/server
             - name: kcp-client-ca
@@ -265,6 +269,11 @@ spec:
         - name: kcp-ca
           secret:
             secretName: {{ include "kcp.fullname" . }}-ca
+        {{- if and .Values.kcpFrontProxy.certificateIssuer .Values.kcpFrontProxy.certificateIssuer.secret }}
+        - name: kcp-front-proxy-ca
+          secret:
+            secretName: {{ required "kcpFrontProxy.certificateIssuer.secret.name is required" .Values.kcpFrontProxy.certificateIssuer.secret.name }}
+        {{- end}}
         - name: kcp-cert
           secret:
             secretName: {{ include "kcp.fullname" .}}-cert

--- a/charts/kcp/templates/server-kubeconfigs.yaml
+++ b/charts/kcp/templates/server-kubeconfigs.yaml
@@ -45,9 +45,11 @@ stringData:
     clusters:
       - name: external-logical-cluster-admin
         cluster:
-          # this references the CA certificate that signed the kcp-front-proxy's certificate
-          # (kcp-server-issuer by default, but could also be any other, external CA)
+          {{- if not .Values.kcpFrontProxy.certificateIssuer }}
           certificate-authority: /etc/kcp/tls/ca/tls.crt
+          {{- else if .Values.kcpFrontProxy.certificateIssuer.secret }}
+          certificate-authority: /etc/kcp-front-proxy/tls/ca/{{ required "kcpFrontProxy.certificateIssuer.secret.key is required" .Values.kcpFrontProxy.certificateIssuer.secret.key }}
+          {{- end}}
           server: "https://{{ .Values.externalHostname }}:{{ if eq .Values.externalPort "" }}{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}{{ else }}{{ .Values.externalPort }}{{- end }}"
     contexts:
       - name: external-logical-cluster

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -119,6 +119,9 @@ kcpFrontProxy:
   # certificateIssuer:
   #   name: ""
   #   kind: Issuer
+  #   secret: # must be a Secret in the same namespace as KCP, containing the CA cert for the issuer
+  #     name: "" # the name of the Secret
+  #     key: "" # the key in the Secret's data that contains the CA cert
   profiling:
     enabled: false
     port: 6060


### PR DESCRIPTION
The kcp chart allows passing a custom `kcpFrontProxy.certificateIssuer` to provide the front-proxy a server cert, instead of the default `kcp-server-issuer`. However, other parts of the chart (notably the front-proxy's ServiceMonitor and the external-admin-kubeconfig) were not properly reacting to this setting.

More precisely, here is the CA cert that should be used by components that try to reach the kcp-front-proxy:
- when no certificateIssuer is provided: the default kcp-ca
- when a *public* certificateIssuer is provided (e.g. LetsEncrypt): no CA
- when a custom *private* certificateIssuser is provided: the CA cert for that private issuer, referenced via `kcpFrontProxy.certificateIssuer.secret`

### Question

@embik should I extend this to also support providing the CA cert via a `ConfigMap`, instead of just `Secret`?

Closes https://github.com/kcp-dev/helm-charts/issues/100