### PR TITLE
Allow setting affinity

### DIFF
--- a/charts/kcp/templates/etcd-statefulset.yaml
+++ b/charts/kcp/templates/etcd-statefulset.yaml
@@ -38,6 +38,10 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app.kubernetes.io/component: "etcd"
     spec:
+      {{- with .Values.etcd.affinity}}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: etcd
           image: {{ .Values.etcd.image }}:{{ .Values.etcd.tag }}

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -58,6 +58,10 @@ spec:
       hostAliases:
         {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 6 }}
       {{- end }}
+      {{- with .Values.kcpFrontProxy.affinity}}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: kcp-front-proxy
           image: "{{ .Values.kcpFrontProxy.image }}:{{- include "frontproxy.version" . }}"

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -94,6 +94,10 @@ spec:
       hostAliases:
         {{- toYaml .Values.kcp.hostAliases.values | nindent 6 }}
       {{- end }}
+      {{- with .Values.etcd.affinity}}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: kcp
           image: {{ .Values.kcp.image }}:{{- include "kcp.version" . }}

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -94,7 +94,7 @@ spec:
       hostAliases:
         {{- toYaml .Values.kcp.hostAliases.values | nindent 6 }}
       {{- end }}
-      {{- with .Values.etcd.affinity}}
+      {{- with .Values.kcp.affinity}}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -21,6 +21,7 @@ etcd:
     enabled: false
     maxUnavailable: 1
   storageClassName: ""
+  affinity: {}
 kcp:
   replicas: 1
   strategy:
@@ -79,6 +80,7 @@ kcp:
   podDisruptionBudget:
     enabled: false
     minAvailable: 1
+  affinity: {}
 kcpFrontProxy:
   replicas: 1
   strategy:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -21,7 +21,18 @@ etcd:
     enabled: false
     maxUnavailable: 1
   storageClassName: ""
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: "app.kubernetes.io/component"
+                  operator: In
+                  values:
+                    - etcd
+            topologyKey: "kubernetes.io/hostname"
 kcp:
   replicas: 1
   strategy:
@@ -80,7 +91,18 @@ kcp:
   podDisruptionBudget:
     enabled: false
     minAvailable: 1
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: "app.kubernetes.io/component"
+                  operator: In
+                  values:
+                    - server
+            topologyKey: "kubernetes.io/hostname"
 kcpFrontProxy:
   replicas: 1
   strategy:
@@ -167,6 +189,18 @@ kcpFrontProxy:
   # - name: example-vw-serving-cert
   #   mountPath: /etc/example-vw-serving-cert
   extraFlags: []
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: "app.kubernetes.io/component"
+                  operator: In
+                  values:
+                    - front-proxy
+            topologyKey: "kubernetes.io/hostname"
 oidc:
   enabled: false
   caSecretName: ""


### PR DESCRIPTION
This PR adds support for setting affinity rules. When running multiple replicas, this allows users to specify affinity settings such as podAntiAffinity to ensure that pods are scheduled on different nodes or apply custom node affinity configurations.

### Testing

used `helm template` to ensure it renders the appropriate objects with and without affinity.