### PR TITLE
set GOMAXPROCS to cpu request

### DIFF
--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -183,6 +183,10 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: requests.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.cpu
           livenessProbe:
             failureThreshold: 6
             httpGet:


### PR DESCRIPTION
When running kcp in production we noticed it is using a significant amount of CPU. In order to help with that we think setting `GOMAXPROCS` to the CPU request may help.

Currently kcp is always consuming the limit set for CPU, if not limit is set it tries to consume all the CPU of the node. In the screenshot provided you can see it was originally consuming almost all CPU of the node, we set a limit and it it constantly at the limit.

![image](https://github.com/user-attachments/assets/d20bbf7a-db1a-4730-93e2-1b9357be9a95)
