### PR TITLE
front-proxy Ingress: add ingressClassName field

### DIFF
--- a/charts/kcp/templates/front-proxy-ingress.yaml
+++ b/charts/kcp/templates/front-proxy-ingress.yaml
@@ -32,6 +32,9 @@ metadata:
   annotations:
     {{- toYaml .Values.kcpFrontProxy.ingress.annotations | nindent 4 }}
 spec:
+  {{- if .Values.kcpFrontProxy.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.kcpFrontProxy.ingress.ingressClassName }}
+  {{- end }}
   tls:
     - hosts:
         - {{ .Values.externalHostname }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -117,8 +117,8 @@ kcpFrontProxy:
     enabled: false
   ingress:
     enabled: false
+    ingressClassName: ""
     annotations:
-      kubernetes.io/ingress.class: "nginx"
       acme.cert-manager.io/http01-edit-in-place: "true"
       # this is ingress-controller-specific and might need configuration
       # depending on the ingress-controller in use.


### PR DESCRIPTION
The kubernetes.io/ingress.class annotation is deprecated since Kubernetes v1.18 (https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#deprecating-the-ingress-class-annotation).

This allows specifying an ingress class via the spec.ingressClassName field of the Ingress resource, and exposes a corresponding kcpFrontProxy.ingress.ingressClassName key in values.yaml.

Note: this should still be fully backwards-compatible. Users that for any reason still want to use the `kubernetes.io/ingress.class` annotation can always leave `ingressClassName` empty and rely on `kcpFrontProxy.ingress.annotations` just like before.