### PR TITLE
Make etcd service more Istio-friendly

### DIFF
--- a/charts/kcp/templates/etcd-certificates.yaml
+++ b/charts/kcp/templates/etcd-certificates.yaml
@@ -29,6 +29,11 @@ spec:
     - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}
   ipAddresses:
     - 0.0.0.0
+    {{- with .Values.certificates.ipAddresses }}
+    {{- range $ip := . }}
+    - {{ $ip }}
+    {{- end }}
+    {{- end }}
   issuerRef:
     name: {{ include "etcd.fullname" . }}-client-issuer
 
@@ -62,6 +67,11 @@ spec:
     - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}
   ipAddresses:
     - 0.0.0.0
+    {{- with .Values.certificates.ipAddresses }}
+    {{- range $ip := . }}
+    - {{ $ip }}
+    {{- end }}
+    {{- end }}
   issuerRef:
     name: {{ include "etcd.fullname" . }}-peer-issuer
 {{- end }}

--- a/charts/kcp/templates/etcd-statefulset.yaml
+++ b/charts/kcp/templates/etcd-statefulset.yaml
@@ -11,8 +11,10 @@ spec:
   ports:
     - port: 2379
       name: client
+      appProtocol: https
     - port: 2380
       name: peer
+      appProtocol: https
   selector:
     {{- include "common.labels.selector" . | nindent 4 }}
     app.kubernetes.io/component: "etcd"

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -240,6 +240,8 @@ certificates:
   # add additional dns names that should be embedded into the kcp server certificate.
   dnsNames:
   - localhost
+  # additional ip addresses to be embedded in the etcd server and peer certs. Can be useful e.g. when using Istio you can pass "127.0.0.6" so the sidecar IP is included.
+  ipAddresses: []
 letsEncrypt:
   enabled: false
   staging:


### PR DESCRIPTION
I tried to set up kcp in a namespace that has istio injection enabled. Unfortunately, it wasn't working (mainly kcp couldn't talk to etcd over the istio-proxy connection) and threw some obscure error messages suggesting authentication failed.

The problem was actually that Istio couldn't detect the right protocol to proxy. I'm adding the `appProtocol` field to both service ports to ensure that Istio knows it has to proxy HTTPS. In addition, the (client) certificates needed to have `127.0.0.6` (the istio-proxy sidecar IP) injected so they'd be accepted by the servers. This PR therefore also adds the option to add more ip addresses to the generated certificates.