### PR TITLE
Update appVersion to 0.26.0, Helm chart version to 0.9.0

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.8.3
-appVersion: "0.25.0"
+version: 0.9.0
+appVersion: "0.26.0"
 
 # optional metadata
 type: application


### PR DESCRIPTION
We just released https://github.com/kcp-dev/kcp/releases/tag/v0.26.0, time to update the Helm chart.