### PR TITLE
Remove emptyDir from kcp Deployment, make root filesystem read-only

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.9.0
+version: 0.9.1
 appVersion: "0.26.0"
 
 # optional metadata

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -102,6 +102,8 @@ spec:
         - name: kcp
           image: {{ .Values.kcp.image }}:{{- include "kcp.version" . }}
           imagePullPolicy: {{ .Values.kcp.pullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: 6443
             {{- if .Values.kcp.profiling.enabled }}
@@ -135,7 +137,7 @@ spec:
             - --requestheader-username-headers=X-Remote-User
             - --requestheader-group-headers=X-Remote-Group
             - --requestheader-extra-headers-prefix=X-Remote-Extra-
-            - --root-directory=/etc/kcp/config
+            - --root-directory=''
             - --shard-virtual-workspace-ca-file=/etc/kcp/tls/ca/tls.crt
             - --shard-base-url=https://{{ include "kcp.fullname" . }}:6443
             - --shard-external-url=https://$(EXTERNAL_HOSTNAME):$(EXTERNAL_PORT)
@@ -260,8 +262,6 @@ spec:
               mountPath: /etc/kcp/external-logical-cluster-admin/kubeconfig
             - name: external-logical-cluster-admin-kubeconfig-cert
               mountPath: /etc/kcp/external-logical-cluster-admin/kubeconfig-client-cert
-            - name: kcp-config
-              mountPath: /etc/kcp/config
       volumes:
         - name: kcp-etcd-client-cert
           secret:
@@ -324,9 +324,6 @@ spec:
         - name: external-logical-cluster-admin-kubeconfig-cert
           secret:
             secretName: {{ include "kcp.fullname" . }}-external-admin-kubeconfig-cert
-        - name: kcp-config
-          emptyDir:
-            sizeLimit: 50Mi
 
 ---
 apiVersion: v1


### PR DESCRIPTION
https://github.com/kcp-dev/kcp/pull/3158 has made it possible to no longer have a defined root directory, so this PR removes the `emptyDir` hack we've had in place for some time and puts the root filesystem into read-only to make sure we don't write anything to the container filesystem by accident.