### PR TITLE
server: wire kcp-ca as root-ca, ending up in service account token secrets

### DIFF
--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -123,7 +123,7 @@ spec:
             - --tls-cert-file=/etc/kcp/tls/server/tls.crt
             - --service-account-key-file=/etc/kcp/tls/service-account/tls.key
             - --service-account-private-key-file=/etc/kcp/tls/service-account/tls.key
-            - --root-ca-file=/etc/kcp/tls/service-account-ca/tls.crt
+            - --root-ca-file=/etc/kcp/tls/ca/tls.crt
             - --enable-home-workspaces={{ .Values.kcp.homeWorkspaces.enabled }}
             {{- if .Values.kcp.logicalClusterAdminFlag }}
             - --logical-cluster-admin-kubeconfig=/etc/kcp/logical-cluster-admin/kubeconfig/kubeconfig


### PR DESCRIPTION
The root-ca must match the serving certs, in particular of the front-proxy.

Note: the shards server deployment is configured like in this PR already, just the single-shard mode is broken.