### PR TITLE
fix (secret): kcp-token-auth-file

### DIFF
--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -184,7 +184,7 @@ spec:
         {{- if .Values.kcp.tokenAuth.enabled }}
         - name: kcp-token-auth-file
           secret:
-            secretName: kcp-token-auth-file
+            secretName: {{ include "kcp.fullname" . }}-token-auth-file
         {{- end }}
         # these volumes are necessary for the path-mapping.yaml
         - name: kcp-ca

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -26,6 +26,7 @@ spec:
     {{- include "common.labels.selector" . | nindent 4 }}
     app.kubernetes.io/component: "front-proxy"
 
+
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
When the `kcp` chart is used as dependency, the volume `kcp-token-auth-file` cannot be created from a hardcoded secret name `kcp-token-auth-file`, because the generated secret includes the name of the release. 

This change uses `kcp.fullname` template helper, similar to how the other secret names are referenced.