### PR TITLE
[charts/kcp] Update kcp version to 0.26.1

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.9.2
-appVersion: "0.26.0"
+version: 0.9.3
+appVersion: "0.26.1"
 
 # optional metadata
 type: application


### PR DESCRIPTION
We are about to release 0.26.1, this is the PR to bump the appVersion.

Only merge after 0.26.1 release has been cut.