### PR TITLE
Move chart-specific README content to chart README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
 # kcp Helm Charts
 
-Repository for kcp helm charts.
+Repository for kcp Helm charts.
 
-Important: charts `proxy`, `shard`, `cache` and `certificates` are work in
-progress and are not ready for production use.
+## Overview
 
-## Pre-requisites
+The following charts are currently available from this repository:
 
-- [cert-manager](https://cert-manager.io/docs/installation) installed and running
-- Ingress installed (e.g. nginx-ingress or OpenShift router)
+- [kcp](./charts/kcp/)
+- [api-syncagent](./charts/api-syncagent/)
+
+> [!CAUTION]
+> The charts below are work-in-progress and currently not ready for production use.
+
+In addition, to support multi-shard kcp setups, we support a collection of charts
+that are meant to be used together:
+
+- [certificates](./charts/certificates/)
+- [shard](./charts/shard/)
+- [proxy](./charts/proxy/)
+- [cache](./charts/cache/)
+
 
 ## Usage
 
@@ -22,192 +33,27 @@ Once Helm has been set up correctly, add the repo as follows:
 If you had already added this repo earlier, run `helm repo update` to retrieve the latest versions
 of the packages. You can then run `helm search repo kcp` to see the charts.
 
-To install the kcp chart:
+For individual usage instructions, please see the respective chart documentation linked above.
 
-    helm install my-kcp kcp/kcp
+## Contributing
 
-To uninstall the chart:
+We ❤️ our contributors! If you're interested in helping us out, please check out [contributing to kcp](https://docs.kcp.io/kcp/latest/contributing/).
 
-    helm delete my-kcp
+This community has a [Code of Conduct](https://github.com/kcp-dev/kcp/blob/main/code-of-conduct.md). Please make sure to follow it.
 
-## Development usage
+## Getting in touch
 
-To install using the local chart:
+There are several ways to communicate with us:
 
-    helm install kcp ./charts/kcp --values ./myvalues.yaml --namespace kcp --create-namespace
+- The [`#kcp-dev` channel](https://app.slack.com/client/T09NY5SBT/C021U8WSAFK) in the [Kubernetes Slack workspace](https://slack.k8s.io).
+- Our mailing lists:
+    - [kcp-dev](https://groups.google.com/g/kcp-dev) for development discussions.
+    - [kcp-users](https://groups.google.com/g/kcp-users) for discussions among users and potential users.
+- By joining the kcp-dev mailing list, you should receive an invite to our bi-weekly community meetings.
+- See recordings of past community meetings on [YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q).
+- The next community meeting dates are available via our [CNCF community group](https://community.cncf.io/kcp/).
+- Check the [community meeting notes document](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4) for future and past meeting agendas.
 
-Changes can then be made locally and tested via upgrade:
+## License
 
-    helm upgrade kcp ./charts/kcp --values ./myvalues.yaml --namespace kcp
-
-Note `myvalues.yaml` will depend on your environment (you must specify which ingress method
-is used to expose the front-proxy endpoint), a minimal example:
-
-```yaml
-externalHostname: "<external hostname as exposed by ingress method below>"
-kcpFrontProxy:
-  ingress:
-    enabled: true
-```
-
-Export the externalHostname variable, that will be used later to interact with kcp setup:
-
-    export KCP_EXTERNAL_HOSTNAME=kcp.dev.local
-
-Note that by default all certificates are signed by the Helm chart's own PKI and so will not be
-trusted by browsers. You can however change the `kcp-front-proxy`'s certificate to be issued
-by, for example, Let's Encrypt. For this you have to enable the creation of the Let's Encrypt
-issuer like so:
-
-```yaml
-externalHostname: "<external hostname as exposed by ingress method below>"
-kcpFrontProxy:
-  ingress:
-    enabled: true
-  certificateIssuer:
-    name: kcp-letsencrypt-prod
-    kind: ClusterIssuer
-letsEncrypt:
-  enabled: true
-  production:
-    enabled: true
-    email: lets-encrypt-notifications@example.com
-```
-
-## Accessing the deployed kcp
-
-To access the deployed kcp, it will be necessary to create a kubeconfig which connects via the
-front-proxy external endpoint (specified via `externalHostname` above).
-
-The content of the kubeconfig will depend on the kcp authentication configuration, below we describe
-one option which uses client-cert auth to enable a kcp-admin user.
-
-:warning: this example allows global admin permissions across all workspaces, you may also want to
-consider using more restricted groups for example `system:kcp:workspace:access` to provide a
-user `system:authenticated` access to a workspace.
-
-### PKI
-
-The chart will create a full PKI system, with root CA, intermediate CAs and more. The diagram below
-shows the default configuration, however the issuer for the `kcp-front-proxy` certificate can be
-configured and used, for example, Let's Encrypt.
-
-```mermaid
-graph TB
-    A([kcp-pki-bootstrap]):::issuer --> B(kcp-pki-ca):::ca
-    B --> C([kcp-pki]):::issuer
-
-    X([lets-encrypt-staging]):::issuer
-    Y([lets-encrypt-prod]):::issuer
-
-    C --> D(kcp-etcd-client-ca):::ca
-    C --> E(kcp-etcd-peer-ca):::ca
-    C --> F(kcp-front-proxy-client-ca):::ca
-    C --> G(kcp-ca):::ca
-    C --> H(kcp-requestheader-client-ca):::ca
-    C --> I(kcp-client-ca):::ca
-    C --> J(kcp-service-account-ca):::ca
-
-    D --> K([kcp-etcd-client-issuer]):::issuer
-    E --> L([kcp-etcd-peer-issuer]):::issuer
-    F --> M([kcp-front-proxy-client-issuer]):::issuer
-    G --> N([kcp-server-issuer]):::issuer
-    H --> O([kcp-requestheader-client-issuer]):::issuer
-    I --> P([kcp-client-issuer]):::issuer
-    J --> Q([kcp-service-account-issuer]):::issuer
-
-    K --- K1(kcp-etcd):::cert --> K2(kcp-etcd-client):::cert
-    L --> L1(kcp-etcd-peer):::cert
-    M --> M1(kcp-external-admin-kubeconfig):::cert
-    N --- N1(kcp):::cert --- N2(kcp-front-proxy):::cert --> N3(kcp-virtual-workspaces):::cert
-    O --- O1(kcp-front-proxy-requestheader):::cert --> O2(kcp-front-proxy-vw-client):::cert
-    P --- P1(kcp-front-proxy-kubeconfig):::cert --> P2(kcp-internal-admin-kubeconfig):::cert
-    Q --> Q1(kcp-service-account):::cert
-
-    classDef issuer color:#77F
-    classDef ca color:#F77
-    classDef cert color:orange
-```
-
-### Create kubeconfig and add CA cert
-
-First we get the CA cert for the front proxy, saving it to a file `ca.crt`
-
-    kubectl get secret kcp-front-proxy-cert -o=jsonpath='{.data.tls\.crt}' | base64 -d > ca.crt
-
-Now we create a new kubeconfig which references the `ca.crt`
-
-    kubectl --kubeconfig=admin.kubeconfig config set-cluster base --server https://$KCP_EXTERNAL_HOSTNAME:443 --certificate-authority=ca.crt
-    kubectl --kubeconfig=admin.kubeconfig config set-cluster root --server https://$KCP_EXTERNAL_HOSTNAME:443/clusters/root --certificate-authority=ca.crt
-
-### Create client-cert credentials
-
-Now we must add credentials to the kubeconfig, so requests to the front-proxy may be authenticated.
-
-One way to do this is to create a client certificate with a cert-manager `Certificate`
-
-    cat <<EOF | kubectl apply -f -
-    apiVersion: cert-manager.io/v1
-    kind: Certificate
-    metadata:
-      name: cluster-admin-client-cert
-    spec:
-      commonName: cluster-admin
-      issuerRef:
-        name: kcp-front-proxy-client-issuer
-      privateKey:
-        algorithm: RSA
-        size: 2048
-      secretName: cluster-admin-client-cert
-      subject:
-        organizations:
-        - system:kcp:admin
-      usages:
-      - client auth
-    EOF
-
-This will result in a `cluster-admin-client-cert` secret which we can again save to local files:
-
-    kubectl get secret cluster-admin-client-cert -o=jsonpath='{.data.tls\.crt}' | base64 -d > client.crt
-    kubectl get secret cluster-admin-client-cert -o=jsonpath='{.data.tls\.key}' | base64 -d > client.key
-    chmod 600 client.crt client.key
-
-We can now add these credentials to the `admin.kubeconfig` and access kcp:
-
-    kubectl --kubeconfig=admin.kubeconfig config set-credentials kcp-admin --client-certificate=client.crt --client-key=client.key
-    kubectl --kubeconfig=admin.kubeconfig config set-context base --cluster=base --user=kcp-admin
-    kubectl --kubeconfig=admin.kubeconfig config set-context root --cluster=root --user=kcp-admin
-    kubectl --kubeconfig=admin.kubeconfig config use-context root
-    kubectl --kubeconfig=admin.kubeconfig workspace
-    export KUBECONFIG=$PWD/admin.kubeconfig
-    kubectl workspace
-    Current workspace is "1gnrr0twy6c3o".
-
-## Install to kind cluster (for development)
-
-There is a helper script to install kcp to a [kind](https://github.com/kubernetes-sigs/kind) cluster.
-It will install cert-manager and kcp. The `kind` cluster binds to host port 8443 for exposing kcp.
-This particular configuration is useful for development and testing, but will not work with Let's Encrypt.
-
-    ./hack/kind-setup.sh
-
-Pre-requisites established by that script:
-
-* `kind` executable installed at `/usr/local/bin/kind`
-* kind cluster named `kcp`
-* [cert-manager](https://cert-manager.io/) installed on the cluster
-* `/etc/hosts` entry for `kcp.dev.local` pointing to `127.0.0.1`
-
-The script will then install kcp the following way:
-
-    helm upgrade --install my-kcp ./charts/kcp/ \
-      --values ./hack/kind-values.yaml \
-      --namespace kcp \
-      --create-namespace
-
-See [hack/kind-values.yaml](./hack/kind-values.yaml) for the values passed to the Helm chart.
-
-# Known issues
-
-* https://github.com/kcp-dev/kcp/issues/2295 - Deployments fail to start.
-Workaround: Delete the corrupted token store file in the `kcp` PersistentVolume and restart kcp pod.
+Helm charts in this repository are licensed under [Apache-2.0](./LICENSE).

--- a/charts/kcp/README.md
+++ b/charts/kcp/README.md
@@ -1,17 +1,206 @@
-# KCP Helm Chart
+# kcp
 
-This Helm chart deploys KCP, including the following components:
+This Helm chart deploys kcp, including the following components:
 
-* KCP pod, including virtual workspace container
-* Etcd
-* Front proxy
+* kcp (server) Pod, including virtual workspace container
+* etcd
+* kcp-front-proxy
 
-## Dependencies
+## Requirements
 
-* cert-manager
-* Openshift route (optional)
+* [cert-manager](https://cert-manager.io/docs/installation)
+* Openshift route support (optional)
 * Ingress Controller (optional)
 * Prometheus Operator (optional, see [Monitoring](#monitoring))
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts. Please refer to Helm's
+[documentation](https://helm.sh/docs) to get started.
+
+Once Helm has been set up correctly, add the repo as follows:
+
+    helm repo add kcp https://kcp-dev.github.io/helm-charts
+
+If you had already added this repo earlier, run `helm repo update` to retrieve the latest versions
+of the packages. You can then run `helm search repo kcp` to see the charts.
+
+To install the kcp chart:
+
+    helm install my-kcp kcp/kcp --values ./myvalues.yaml
+
+To uninstall the chart:
+
+    helm delete my-kcp
+
+Note that `myvalues.yaml` will depend on your environment (you must specify which ingress method
+is used to expose the front-proxy endpoint), a minimal example:
+
+```yaml
+externalHostname: "<external hostname as exposed by ingress method below>"
+kcpFrontProxy:
+  ingress:
+    enabled: true
+```
+
+Export the externalHostname variable, that will be used later to interact with kcp setup:
+
+    export KCP_EXTERNAL_HOSTNAME=kcp.dev.local
+
+
+## PKI
+
+The chart will create a full PKI system, with root CA, intermediate CAs and more. The diagram below
+shows the default configuration, however the issuer for the `kcp-front-proxy` certificate can be
+configured and used, for example, Let's Encrypt.
+
+```mermaid
+graph TB
+    A([kcp-pki-bootstrap]):::issuer --> B(kcp-pki-ca):::ca
+    B --> C([kcp-pki]):::issuer
+
+    X([lets-encrypt-staging]):::issuer
+    Y([lets-encrypt-prod]):::issuer
+
+    C --> D(kcp-etcd-client-ca):::ca
+    C --> E(kcp-etcd-peer-ca):::ca
+    C --> F(kcp-front-proxy-client-ca):::ca
+    C --> G(kcp-ca):::ca
+    C --> H(kcp-requestheader-client-ca):::ca
+    C --> I(kcp-client-ca):::ca
+    C --> J(kcp-service-account-ca):::ca
+
+    D --> K([kcp-etcd-client-issuer]):::issuer
+    E --> L([kcp-etcd-peer-issuer]):::issuer
+    F --> M([kcp-front-proxy-client-issuer]):::issuer
+    G --> N([kcp-server-issuer]):::issuer
+    H --> O([kcp-requestheader-client-issuer]):::issuer
+    I --> P([kcp-client-issuer]):::issuer
+    J --> Q([kcp-service-account-issuer]):::issuer
+
+    K --- K1(kcp-etcd):::cert --> K2(kcp-etcd-client):::cert
+    L --> L1(kcp-etcd-peer):::cert
+    M --> M1(kcp-external-admin-kubeconfig):::cert
+    N --- N1(kcp):::cert --- N2(kcp-front-proxy):::cert --> N3(kcp-virtual-workspaces):::cert
+    O --- O1(kcp-front-proxy-requestheader):::cert --> O2(kcp-front-proxy-vw-client):::cert
+    P --- P1(kcp-front-proxy-kubeconfig):::cert --> P2(kcp-internal-admin-kubeconfig):::cert
+    Q --> Q1(kcp-service-account):::cert
+
+    classDef issuer color:#77F
+    classDef ca color:#F77
+    classDef cert color:orange
+```
+
+Note that by default all certificates are signed by the Helm chart's own PKI and so will not be
+trusted by browsers. You can however change the `kcp-front-proxy`'s certificate to be issued
+by, for example, Let's Encrypt. For this you have to enable the creation of the Let's Encrypt
+issuer like so:
+
+```yaml
+externalHostname: "<external hostname as exposed by ingress method below>"
+kcpFrontProxy:
+  ingress:
+    enabled: true
+  certificateIssuer:
+    name: kcp-letsencrypt-prod
+    kind: ClusterIssuer
+letsEncrypt:
+  enabled: true
+  production:
+    enabled: true
+    email: lets-encrypt-notifications@example.com
+```
+
+## Access
+
+To access the deployed kcp, it will be necessary to create a kubeconfig which connects via the
+front-proxy external endpoint (specified via `externalHostname` above).
+
+The content of the kubeconfig will depend on the kcp authentication configuration, below we describe
+one option which uses client-cert auth to enable a kcp-admin user.
+
+:warning: this example allows global admin permissions across all workspaces, you may also want to
+consider using more restricted groups for example `system:kcp:workspace:access` to provide a
+user `system:authenticated` access to a workspace.
+
+### Create kubeconfig and add CA cert
+
+First we get the CA cert for the front proxy, saving it to a file `ca.crt`
+
+    kubectl get secret kcp-front-proxy-cert -o=jsonpath='{.data.tls\.crt}' | base64 -d > ca.crt
+
+Now we create a new kubeconfig which references the `ca.crt`
+
+    kubectl --kubeconfig=admin.kubeconfig config set-cluster base --server https://$KCP_EXTERNAL_HOSTNAME:443 --certificate-authority=ca.crt
+    kubectl --kubeconfig=admin.kubeconfig config set-cluster root --server https://$KCP_EXTERNAL_HOSTNAME:443/clusters/root --certificate-authority=ca.crt
+
+### Create client-cert credentials
+
+Now we must add credentials to the kubeconfig, so requests to the front-proxy may be authenticated.
+
+One way to do this is to create a client certificate with a cert-manager `Certificate`
+
+    cat <<EOF | kubectl apply -f -
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: cluster-admin-client-cert
+    spec:
+      commonName: cluster-admin
+      issuerRef:
+        name: kcp-front-proxy-client-issuer
+      privateKey:
+        algorithm: RSA
+        size: 2048
+      secretName: cluster-admin-client-cert
+      subject:
+        organizations:
+        - system:kcp:admin
+      usages:
+      - client auth
+    EOF
+
+This will result in a `cluster-admin-client-cert` secret which we can again save to local files:
+
+    kubectl get secret cluster-admin-client-cert -o=jsonpath='{.data.tls\.crt}' | base64 -d > client.crt
+    kubectl get secret cluster-admin-client-cert -o=jsonpath='{.data.tls\.key}' | base64 -d > client.key
+    chmod 600 client.crt client.key
+
+We can now add these credentials to the `admin.kubeconfig` and access kcp:
+
+    kubectl --kubeconfig=admin.kubeconfig config set-credentials kcp-admin --client-certificate=client.crt --client-key=client.key
+    kubectl --kubeconfig=admin.kubeconfig config set-context base --cluster=base --user=kcp-admin
+    kubectl --kubeconfig=admin.kubeconfig config set-context root --cluster=root --user=kcp-admin
+    kubectl --kubeconfig=admin.kubeconfig config use-context root
+    kubectl --kubeconfig=admin.kubeconfig workspace
+    export KUBECONFIG=$PWD/admin.kubeconfig
+    kubectl workspace
+    Current workspace is "1gnrr0twy6c3o".
+
+## Install to kind cluster (for development)
+
+There is a helper script to install kcp to a [kind](https://github.com/kubernetes-sigs/kind) cluster.
+It will install cert-manager and kcp. The `kind` cluster binds to host port 8443 for exposing kcp.
+This particular configuration is useful for development and testing, but will not work with Let's Encrypt.
+From the root directory of this repository, run:
+
+    ./hack/kind-setup.sh
+
+Pre-requisites established by that script:
+
+* `kind` executable installed at `/usr/local/bin/kind`
+* kind cluster named `kcp`
+* [cert-manager](https://cert-manager.io/) installed on the cluster
+* `/etc/hosts` entry for `kcp.dev.local` pointing to `127.0.0.1`
+
+The script will then install kcp the following way:
+
+    helm upgrade --install my-kcp ./charts/kcp/ \
+      --values ./hack/kind-values.yaml \
+      --namespace kcp \
+      --create-namespace
+
+See [hack/kind-values.yaml](./hack/kind-values.yaml) for the values passed to the Helm chart.
 
 ## Options
 


### PR DESCRIPTION
Since this repository is becoming a multi-chart repository (it always has been, but we haven't treated the multi-shard charts really well) with `kcp`, `api-syncagent` and soon `kcp-operator`, I would like to propose that we move content specific to the `kcp` chart out of the main repository README and into `charts/kcp/README.md`.