### PR TITLE
api-syncagent: add extraFlags, extraVolumes and extraVolumeMounts to chart values

### DIFF
--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
             {{- with .Values.publishedResourceSelector }}
             - "--published-resource-selector={{ . }}"
             {{- end }}
+            {{- range .Values.extraFlags }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -68,6 +71,9 @@ spec:
             - name: cluster-kubeconfig
               mountPath: /etc/api-syncagent/cluster
           {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+{{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -83,3 +89,7 @@ spec:
           secret:
             secretName: "{{ . }}"
         {{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -47,3 +47,17 @@ resources:
 crds:
   # Whether to install the PublishedResource CRD.
   enabled: true
+
+# Optional: Pass additional flags to the kcp-api-syncagent process started by the container.
+extraFlags: []
+
+# Optional: Configure additional volumes to be added to the syncagent Pod.
+extraVolumes: []
+#  - name: extra-secret
+#    secret:
+#      secretName: extra-secret
+
+# Optional: Configure additional volume mounts to be added to the agent container.
+extraVolumeMounts: []
+#  - name: extra-secret
+#    mountPath: /etc/test


### PR DESCRIPTION
This adds `extraFlags`, `extraVolumes` and `extraVolumeMounts` to the `api-syncagent` chart to be able to configure additional volumes and flags into the api-syncagent `Deployment`.

Useful for situations where we want to pass a kubeconfig without embedded certificates or when we pass `--kubeconfig-ca-file-override`.