### PR TITLE
Update to api-syncagent 0.1.0 and bump chart

### DIFF
--- a/charts/api-syncagent/Chart.yaml
+++ b/charts/api-syncagent/Chart.yaml
@@ -3,8 +3,8 @@ name: api-syncagent
 description: A Kubernetes agent to synchronize APIs and their objects between Kubernetes clusters and kcp.
 
 # version information
-version: 0.0.1
-appVersion: "0.0.0"
+version: 0.1.0
+appVersion: "v0.1.0"
 
 # optional metadata
 type: application

--- a/charts/api-syncagent/templates/_helpers.tpl
+++ b/charts/api-syncagent/templates/_helpers.tpl
@@ -1,11 +1,2 @@
 {{- define "name" -}}{{ .Release.Name }}{{- end }}
 {{- define "agentname" -}}{{ .Values.agentName | default .Release.Name }}{{- end }}
-
-{{/* create a container image reference */}}
-{{- define "image" -}}
-   {{- $default := (index . 0).Values.image -}}
-   {{- $this := (index . 1) -}}
-
-   {{- $this.repository | default $default.repository -}}:
-   {{- $this.tag | default $default.tag -}}
-{{- end }}

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
               value: '{{ required "APIExport name must be configured" .Values.apiExportName }}'
             - name: AGENT_NAME
               value: '{{ template "agentname" . }}'
-          image: '{{ template "image" (list $ .Values.image) }}'
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           resources: {{ .Values.resources | toYaml | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
We just released api-syncagent [v0.1.0](https://github.com/kcp-dev/api-syncagent/releases/tag/v0.1.0) 🎉 

This brings the Helm chart to version 0.1.0, sets the proper appVersion and fixes image defaulting to the chart version. The used template honestly looks needlessly complex, the new snippet is what is also used in default templates generated by `helm` (see #126 for comparison).