### PR TITLE
feat(podAnnotations): allow for podAnnotations on kcp server deployment

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.9.3
+version: 0.9.4
 appVersion: "0.26.1"
 
 # optional metadata

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -85,6 +85,10 @@ spec:
       labels:
         {{- include "common.labels" . | nindent 8 }}
         app.kubernetes.io/component: "server"
+      annotations:
+      {{- with .Values.kcp.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.kcp.securityContext }}
       securityContext:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -55,6 +55,7 @@ kcp:
       # cpu: 1
       memory: 20Gi
   volumeClassName: ""
+  podAnnotations: {}
   etcd:
     # set this if you are using external etcds. Do not set this to "embedded", it is not supported.
     serverAddress: ""


### PR DESCRIPTION
This PR adds the ability to add `podAnnotations` to the server deployment to further configure its integration into other systems like e.g. istio