### PR TITLE
feat: allow to configure extraDNSNames to be added to the frontproxy certificate

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.9.4
+version: 0.9.5
 appVersion: "0.26.1"
 
 # optional metadata

--- a/charts/kcp/templates/front-proxy-certificates.yaml
+++ b/charts/kcp/templates/front-proxy-certificates.yaml
@@ -19,6 +19,9 @@ spec:
     - server auth
   dnsNames:
     - "{{ .Values.externalHostname }}"
+    {{- range .Values.kcpFrontProxy.extraDNSNames }}
+    - "{{ . }}"
+    {{- end }}
   issuerRef:
     {{- if .Values.kcpFrontProxy.certificateIssuer }}
     {{ .Values.kcpFrontProxy.certificateIssuer | toYaml | nindent 4 }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -185,6 +185,9 @@ kcpFrontProxy:
   #  proxy_client_cert: /etc/kcp-front-proxy/requestheader-client/tls/kcp/tls.crt
   #  proxy_client_key: /etc/kcp-front-proxy/requestheader-client/tls/kcp/tls.key
 
+  # Set this to add additional dnsNames to the Front Proxy certificate.
+  extraDNSNames: []
+
   # When running external virtual workspaces, kcp-front-proxy needs
   # access to the CA that signed the VW's serving cert. Unless your
   # VWs all use the kcp-server-issuer, you must mount all additional


### PR DESCRIPTION
This feature is particularly useful when deploying into KCP via a tool like flux from a local kind cluster. Setting these additional dnsNames allows you for example to use the cluster internal service name in a kubeconfig to deploy with flux.