### PR TITLE
Update kcp chart to version 0.10.0 (appVersion 0.27.1)

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.9.6
-appVersion: "0.26.3"
+version: 0.10.0
+appVersion: "0.27.1"
 
 # optional metadata
 type: application


### PR DESCRIPTION
We just released kcp 0.27.1 which addressed an upgrade issue from 0.26, so it's time to bring the Helm chart up to this version.