### PR TITLE
Add the ability to provide imagePullSecrets for private Registries or Registries with auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 
 # output of hack/ci/validate-helm-resources.sh
 *-templated.yaml
+
+# remove local development nix configs
+*.nix
+*.lock

--- a/charts/api-syncagent/templates/_helpers.tpl
+++ b/charts/api-syncagent/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 {{- define "imagePullSecrets" -}}
 {{- range .Values.global.imagePullSecrets }}
 {{- if eq (typeOf .) "map[string]interface {}" }}
-{{ toYaml . | trim }}
+- {{ toYaml . | trim }}
 {{- else }}
 - name: {{ . }}
 {{- end }}

--- a/charts/api-syncagent/templates/_helpers.tpl
+++ b/charts/api-syncagent/templates/_helpers.tpl
@@ -1,2 +1,12 @@
 {{- define "name" -}}{{ .Release.Name }}{{- end }}
 {{- define "agentname" -}}{{ .Values.agentName | default .Release.Name }}{{- end }}
+
+{{- define "imagePullSecrets" -}}
+{{- range .Values.global.imagePullSecrets }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
+{{ toYaml . | trim }}
+{{- else }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         app.kubernetes.io/instance: '{{ template "agentname" . }}'
         app.kubernetes.io/version: '{{ .Values.image.tag | default .Chart.AppVersion }}'
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "imagePullSecrets" . | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: agent
           args:

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -1,3 +1,11 @@
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+  # or
+  # - "image-pull-secret"
 # Required: the name of the APIExport in kcp that this Sync Agent is supposed to serve.
 apiExportName: ""
 

--- a/charts/cache/templates/_helpers.tpl
+++ b/charts/cache/templates/_helpers.tpl
@@ -22,7 +22,7 @@
 {{- define "kcp.imagePullSecrets" -}}
 {{- range .Values.global.imagePullSecrets }}
 {{- if eq (typeOf .) "map[string]interface {}" }}
-{{ toYaml . | trim }}
+- {{ toYaml . | trim }}
 {{- else }}
 - name: {{ . }}
 {{- end }}

--- a/charts/cache/templates/_helpers.tpl
+++ b/charts/cache/templates/_helpers.tpl
@@ -19,6 +19,16 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "kcp.imagePullSecrets" -}}
+{{- range .Values.global.imagePullSecrets }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
+{{ toYaml . | trim }}
+{{- else }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "certificates.kcp" -}}
 {{- if not (eq .Values.certificates.name "") -}}
 {{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}

--- a/charts/cache/templates/cache-deployment.yaml
+++ b/charts/cache/templates/cache-deployment.yaml
@@ -47,6 +47,10 @@ spec:
       hostAliases:
         {{- toYaml .Values.cache.hostAliases.values | nindent 6 }}
       {{- end }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "kcp.imagePullSecrets" . | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: cache
           image: {{ .Values.cache.image }}:{{- include "cache.version" . }}

--- a/charts/cache/values.yaml
+++ b/charts/cache/values.yaml
@@ -1,4 +1,11 @@
-externalHostname: ""
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+  # or
+  # - "image-pull-secret"externalHostname: ""
 cache:
   enabled: true
   image: ghcr.io/kcp-dev/kcp

--- a/charts/cache/values.yaml
+++ b/charts/cache/values.yaml
@@ -5,7 +5,8 @@ global:
   imagePullSecrets: []
   # - name: "image-pull-secret"
   # or
-  # - "image-pull-secret"externalHostname: ""
+  # - "image-pull-secret"
+externalHostname: ""
 cache:
   enabled: true
   image: ghcr.io/kcp-dev/kcp

--- a/charts/kcp-operator/templates/_helpers.tpl
+++ b/charts/kcp-operator/templates/_helpers.tpl
@@ -11,7 +11,7 @@ Define imagePullSecrets for the chart.
 {{- define "kcp-operator.imagePullSecrets" -}}
 {{- range .Values.global.imagePullSecrets }}
 {{- if eq (typeOf .) "map[string]interface {}" }}
-{{ toYaml . | trim }}
+- {{ toYaml . | trim }}
 {{- else }}
 - name: {{ . }}
 {{- end }}

--- a/charts/kcp-operator/templates/_helpers.tpl
+++ b/charts/kcp-operator/templates/_helpers.tpl
@@ -6,6 +6,19 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Define imagePullSecrets for the chart.
+*/}}
+{{- define "kcp-operator.imagePullSecrets" -}}
+{{- range .Values.global.imagePullSecrets }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
+{{ toYaml . | trim }}
+{{- else }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/kcp-operator/templates/deployment.yaml
+++ b/charts/kcp-operator/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       serviceAccountName: {{ include "kcp-operator.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "kcp-operator.imagePullSecrets" . | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/kcp-operator/values.yaml
+++ b/charts/kcp-operator/values.yaml
@@ -1,6 +1,13 @@
 # Default values for kcp-operator.
 # Declare variables to be passed into your templates.
-
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+  # or
+  # - "image-pull-secret"
 # This is to override the chart name.
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/kcp/templates/_helpers.tpl
+++ b/charts/kcp/templates/_helpers.tpl
@@ -38,7 +38,7 @@ v{{- .Chart.AppVersion -}}
 {{- define "kcp.imagePullSecrets" -}}
 {{- range .Values.global.imagePullSecrets }}
 {{- if eq (typeOf .) "map[string]interface {}" }}
-{{ toYaml . | trim }}
+- {{ toYaml . | trim }}
 {{- else }}
 - name: {{ . }}
 {{- end }}

--- a/charts/kcp/templates/_helpers.tpl
+++ b/charts/kcp/templates/_helpers.tpl
@@ -35,6 +35,16 @@ v{{- .Chart.AppVersion -}}
 {{- $batteries | uniq | join "," -}}
 {{- end -}}
 
+{{- define "kcp.imagePullSecrets" -}}
+{{- range .Values.global.imagePullSecrets }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
+{{ toYaml . | trim }}
+{{- else }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "frontproxy.fullname" -}}
 {{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 52 | trimSuffix "-" -}}
 {{- printf "%s-front-proxy" $trimmedName | trunc 63 | trimSuffix "-" -}}

--- a/charts/kcp/templates/etcd-statefulset.yaml
+++ b/charts/kcp/templates/etcd-statefulset.yaml
@@ -48,6 +48,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "kcp.imagePullSecrets" . | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: etcd
           image: {{ .Values.etcd.image }}:{{ .Values.etcd.tag }}

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -66,6 +66,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "kcp.imagePullSecrets" . | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: kcp-front-proxy
           image: "{{ .Values.kcpFrontProxy.image }}:{{- include "frontproxy.version" . }}"

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -106,6 +106,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "kcp.imagePullSecrets" . | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: kcp
           image: {{ .Values.kcp.image }}:{{- include "kcp.version" . }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -1,3 +1,11 @@
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+  # or
+  # - "image-pull-secret"
 externalHostname: ""
 externalPort: "" # defaults to 8443 for .Values.kcpFrontProxy.service.type "LoadBalancer", 443 otherwise.
 etcd:

--- a/charts/proxy/templates/_helpers.tpl
+++ b/charts/proxy/templates/_helpers.tpl
@@ -22,7 +22,7 @@
 {{- define "kcp.imagePullSecrets" -}}
 {{- range .Values.global.imagePullSecrets }}
 {{- if eq (typeOf .) "map[string]interface {}" }}
-{{ toYaml . | trim }}
+- {{ toYaml . | trim }}
 {{- else }}
 - name: {{ . }}
 {{- end }}

--- a/charts/proxy/templates/_helpers.tpl
+++ b/charts/proxy/templates/_helpers.tpl
@@ -19,6 +19,16 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "kcp.imagePullSecrets" -}}
+{{- range .Values.global.imagePullSecrets }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
+{{ toYaml . | trim }}
+{{- else }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "certificates.kcp" -}}
 {{- if not (eq .Values.certificates.name "") -}}
 {{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}

--- a/charts/proxy/templates/front-proxy-deployment.yaml
+++ b/charts/proxy/templates/front-proxy-deployment.yaml
@@ -72,6 +72,10 @@ spec:
       hostAliases:
         {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 6 }}
       {{- end }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "kcp.imagePullSecrets" . | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: kcp-front-proxy
           image: "{{ .Values.kcpFrontProxy.image }}:{{- include "frontproxy.version" . }}"

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -5,7 +5,7 @@ global:
   imagePullSecrets: []
   # - name: "image-pull-secret"
   # or
-  # - "image-pull-secret"externalHostname: ""
+  # - "image-pull-secret"
 externalHostname: ""
 kcpFrontProxy:
   enabled: true

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -1,4 +1,11 @@
-externalHostname: ""
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+  # or
+  # - "image-pull-secret"externalHostname: ""
 kcpFrontProxy:
   enabled: true
   image: ghcr.io/kcp-dev/kcp

--- a/charts/proxy/values.yaml
+++ b/charts/proxy/values.yaml
@@ -6,6 +6,7 @@ global:
   # - name: "image-pull-secret"
   # or
   # - "image-pull-secret"externalHostname: ""
+externalHostname: ""
 kcpFrontProxy:
   enabled: true
   image: ghcr.io/kcp-dev/kcp

--- a/charts/shard/templates/_helpers.tpl
+++ b/charts/shard/templates/_helpers.tpl
@@ -22,7 +22,7 @@
 {{- define "kcp.imagePullSecrets" -}}
 {{- range .Values.global.imagePullSecrets }}
 {{- if eq (typeOf .) "map[string]interface {}" }}
-{{ toYaml . | trim }}
+- {{ toYaml . | trim }}
 {{- else }}
 - name: {{ . }}
 {{- end }}

--- a/charts/shard/templates/_helpers.tpl
+++ b/charts/shard/templates/_helpers.tpl
@@ -19,6 +19,16 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "kcp.imagePullSecrets" -}}
+{{- range .Values.global.imagePullSecrets }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
+{{ toYaml . | trim }}
+{{- else }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "certificates.kcp" -}}
 {{- if not (eq .Values.certificates.name "") -}}
 {{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}

--- a/charts/shard/templates/server-deployment.yaml
+++ b/charts/shard/templates/server-deployment.yaml
@@ -108,6 +108,10 @@ spec:
       hostAliases:
         {{- toYaml .Values.kcp.hostAliases.values | nindent 6 }}
       {{- end }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "kcp.imagePullSecrets" . | trim | nindent 8 }}
+      {{- end }}
       containers:
         - name: kcp
           image: {{ .Values.kcp.image }}:{{- include "kcp.version" . }}

--- a/charts/shard/values.yaml
+++ b/charts/shard/values.yaml
@@ -1,3 +1,11 @@
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+  # or
+  # - "image-pull-secret"externalHostname: ""
 externalHostname: ""
 etcd:
   enabled: true


### PR DESCRIPTION
When trying to use the provided helm charts in an air-gapped environment (or) with a private registry using authentication it will fail. This PR adds the ability to optionally provide imagePullSecrets for every chart.

Tested it on a local kind cluster and validated the Deployment manifests with and without providing imagePullSecrets.