### PR TITLE
Pass correct `--root-directory` flag to disable `/data` directory creation

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.10.0
+version: 0.10.1
 appVersion: "0.27.1"
 
 # optional metadata

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -149,7 +149,7 @@ spec:
             - --requestheader-username-headers=X-Remote-User
             - --requestheader-group-headers=X-Remote-Group
             - --requestheader-extra-headers-prefix=X-Remote-Extra-
-            - --root-directory=''
+            - --root-directory=
             - --shard-virtual-workspace-ca-file=/etc/kcp/tls/ca/tls.crt
             - --shard-base-url=https://{{ include "kcp.fullname" . }}:6443
             - --shard-external-url=https://$(EXTERNAL_HOSTNAME):$(EXTERNAL_PORT)


### PR DESCRIPTION
I messed this up a while ago (in #111), the `''` resulted in kcp trying to create `/data/''` as root directory. This only worked because of https://github.com/kcp-dev/kcp/pull/3434 (our Dockerfile having a `VOLUME` directory which mounted a temporary volume into containers, but only in containerd; CRI-O is not mounting such a temporary volume).

We already saw this in https://github.com/kcp-dev/kcp-operator/pull/22 but forgot to check and fix the Helm chart as well.