### PR TITLE
Make LB IP configurable for kcp-front-proxy service

### DIFF
--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   clusterIP: {{ . }}
   {{- end }}
   {{- if and (.Values.kcpFrontProxy.service.type == "LoadBalancer") (.Values.kcpFrontProxy.service.loadBalancerIP) }}
-  loadBalancerIP: {{ . }}
+  loadBalancerIP: {{ .Values.kcpFrontProxy.service.loadBalancerIP }}
   {{- end }}
   type: {{ .Values.kcpFrontProxy.service.type }}
   ports:

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -13,7 +13,7 @@ spec:
   {{- with .Values.kcpFrontProxy.service.clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
-  {{- if and (.Values.kcpFrontProxy.service.type == "LoadBalancer") (.Values.kcpFrontProxy.service.loadBalancerIP) }}
+  {{- if and (eq .Values.kcpFrontProxy.service.type "LoadBalancer") (.Values.kcpFrontProxy.service.loadBalancerIP) }}
   loadBalancerIP: {{ .Values.kcpFrontProxy.service.loadBalancerIP }}
   {{- end }}
   type: {{ .Values.kcpFrontProxy.service.type }}

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -13,6 +13,9 @@ spec:
   {{- with .Values.kcpFrontProxy.service.clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
+  {{- if and (.Values.kcpFrontProxy.service.type == "LoadBalancer") (.Values.kcpFrontProxy.service.loadBalancerIP) }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
   type: {{ .Values.kcpFrontProxy.service.type }}
   ports:
     - protocol: TCP

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -168,6 +168,9 @@ kcpFrontProxy:
     # set this if you want to control the assigned service IP for the kcp-front-proxy
     # service.
     clusterIP: ""
+    # Pre-defined IP address of the kcp-front-proxy Service. (only applies if type is "LoadBalancer")
+    # Used by cloud providers to connect the resulting load balancer service to a pre-existing static IP.
+    loadBalancerIP: ""
   # set this if you want kcp-front-proxy to use a specific certificate issuer
   # (e.g. the Let's Encrypt ones in this chart).
   # certificateIssuer:


### PR DESCRIPTION
This PR will add the configuration to use pre-existing LoadBalancer IP addresses for the kcp-front-proxy service.