### PR TITLE
charts/kcp-operator: add ConfigMap RBAC permissions

### DIFF
--- a/charts/kcp-operator/templates/rbac.yaml
+++ b/charts/kcp-operator/templates/rbac.yaml
@@ -35,6 +35,7 @@ rules:
   resources:
   - secrets
   - services
+  - configmaps
   verbs:
   - create
   - delete


### PR DESCRIPTION
Since https://github.com/kcp-dev/kcp-operator/pull/20, `ConfigMap` permissions are required by kcp-operator.