### PR TITLE
Add xrstf to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,4 @@ approvers:
   - sttts
   - mjudeikis
   - embik
+  - xrstf


### PR DESCRIPTION
@xrstf is a @kcp-dev maintainer, so it feels arbitrary that he isn't in the list of owners for this specific repository. Let's add him here.