### PR TITLE
charts/kcp-operator: bump to initial release version v0.1.0

### DIFF
--- a/charts/kcp-operator/Chart.yaml
+++ b/charts/kcp-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp-operator
 description: A Helm chart for kcp-operator, a Kubernetes operator to deploy and manage kcp instances.
 
 # version information
-version: 0.0.1
-appVersion: "0.0.0"
+version: 0.1.0
+appVersion: "v0.1.0"
 
 # optional metadata
 type: application

--- a/charts/kcp-operator/README.md
+++ b/charts/kcp-operator/README.md
@@ -1,0 +1,6 @@
+# KCP Helm Chart - kcp-operator
+
+This Helm chart deploys an instance of the [kcp-operator](https://github.com/kcp-dev/kcp-operator).
+For more documentation, check out [docs.kcp.io/kcp-operator](https://docs.kcp.io/kcp-operator).
+
+Check [values.yaml](./values.yaml) for configuration options for this Helm chart.


### PR DESCRIPTION
kcp-operator [v0.1.0](https://github.com/kcp-dev/kcp-operator/releases/tag/v0.1.0) is out. Let's bump the Helm chart accordingly.