### PR TITLE
charts/kcp-operator: include updated CRDs from v0.1.0 release

### DIFF
--- a/charts/kcp-operator/Chart.yaml
+++ b/charts/kcp-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp-operator
 description: A Helm chart for kcp-operator, a Kubernetes operator to deploy and manage kcp instances.
 
 # version information
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.1.0"
 
 # optional metadata

--- a/charts/kcp-operator/templates/crds.yaml
+++ b/charts/kcp-operator/templates/crds.yaml
@@ -14,48 +14,71 @@ spec:
     singular: cacheserver
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: CacheServer is the Schema for the cacheservers API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: CacheServerSpec defines the desired state of CacheServer.
-            properties:
-              etcd:
-                description: Etcd configures the etcd cluster that this cache server
-                  should be using.
-                properties:
-                  endpoints:
-                    description: Endpoints is a list of http urls at which etcd nodes
-                      are available. The expected format is "https://etcd-hostname:2379".
-                    items:
-                      type: string
-                    type: array
-                  tlsConfig:
-                    description: ClientCert configures the client certificate used
-                      to access etcd.
-                    properties:
-                      secretRef:
-                        description: SecretRef is the reference to a v1.Secret object
-                          that contains the TLS certificate.
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: CacheServer is the Schema for the cacheservers API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CacheServerSpec defines the desired state of CacheServer.
+              properties:
+                etcd:
+                  description: Etcd configures the etcd cluster that this cache server should be using.
+                  properties:
+                    endpoints:
+                      description: Endpoints is a list of http urls at which etcd nodes are available. The expected format is "https://etcd-hostname:2379".
+                      items:
+                        type: string
+                      type: array
+                    tlsConfig:
+                      description: ClientCert configures the client certificate used to access etcd.
+                      properties:
+                        secretRef:
+                          description: SecretRef is the reference to a v1.Secret object that contains the TLS certificate.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - secretRef
+                      type: object
+                  required:
+                    - endpoints
+                  type: object
+                image:
+                  description: 'Optional: Image overwrites the container image used to deploy the cache server.'
+                  properties:
+                    imagePullSecrets:
+                      description: 'Optional: ImagePullSecrets is a list of secret references that should be used as image pull secrets (e.g. when a private registry is used).'
+                      items:
+                        description: |-
+                          LocalObjectReference contains enough information to let you locate the
+                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
@@ -68,57 +91,25 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
-                    required:
-                    - secretRef
-                    type: object
-                required:
-                - endpoints
-                type: object
-              image:
-                description: 'Optional: Image overwrites the container image used
-                  to deploy the cache server.'
-                properties:
-                  imagePullSecrets:
-                    description: 'Optional: ImagePullSecrets is a list of secret references
-                      that should be used as image pull secrets (e.g. when a private
-                      registry is used).'
-                    items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
-                      properties:
-                        name:
-                          default: ""
-                          description: |-
-                            Name of the referent.
-                            This field is effectively required, but due to backwards compatibility is
-                            allowed to be empty. Instances of this type with an empty value here are
-                            almost certainly wrong.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          type: string
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    type: array
-                  repository:
-                    description: Repository is the container image repository to use
-                      for KCP containers. Defaults to `ghcr.io/kcp-dev/kcp`.
-                    type: string
-                  tag:
-                    description: Tag is the container image tag to use for KCP containers.
-                      Defaults to the latest kcp release that the operator supports.
-                    type: string
-                type: object
-            required:
-            - etcd
-            type: object
-          status:
-            description: CacheServerStatus defines the observed state of CacheServer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                      type: array
+                    repository:
+                      description: Repository is the container image repository to use for KCP containers. Defaults to `ghcr.io/kcp-dev/kcp`.
+                      type: string
+                    tag:
+                      description: Tag is the container image tag to use for KCP containers. Defaults to the latest kcp release that the operator supports.
+                      type: string
+                  type: object
+              required:
+                - etcd
+              type: object
+            status:
+              description: CacheServerStatus defines the observed state of CacheServer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -135,113 +126,1539 @@ spec:
     singular: frontproxy
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: FrontProxy is the Schema for the frontproxies API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: FrontProxySpec defines the desired state of FrontProxy.
-            properties:
-              auth:
-                description: 'Optional: Auth configures various aspects of Authentication
-                  and Authorization for this front-proxy instance.'
-                properties:
-                  oidc:
-                    description: 'Optional: OIDC configures OpenID Connect Authentication'
+    - additionalPrinterColumns:
+        - jsonPath: .spec.rootShard.ref.name
+          name: RootShard
+          type: string
+        - jsonPath: .spec.externalHostname
+          name: ExternalHostname
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: FrontProxy is the Schema for the frontproxies API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FrontProxySpec defines the desired state of FrontProxy.
+              properties:
+                additionalPathMappings:
+                  description: 'Optional: AdditionalPathMappings configures // TODO ?'
+                  items:
+                    description: so we have to copy the struct type
                     properties:
-                      clientID:
-                        description: ClientID is the OIDC client ID configured on
-                          the issuer side for this KCP instance.
+                      backend:
                         type: string
-                      clientSecret:
-                        description: |-
-                          Optionally provide the client secret for the OIDC client. This is not used by KCP itself, but is used to generate
-                          a OIDC kubeconfig that can be shared with users to log in via the OIDC provider.
+                      backend_server_ca:
                         type: string
-                      enabled:
-                        type: boolean
-                      groupsClaim:
-                        description: 'Experimental: Optionally provides a custom claim
-                          for fetching groups. The claim must be a string or an array
-                          of strings.'
+                      path:
                         type: string
-                      groupsPrefix:
-                        description: |-
-                          Optionally sets a custom groups prefix. This defaults to "oidc:" if unset, which means a group called "group1"
-                          on the OIDC side will be recognised as "oidc:group1" in KCP.
+                      proxy_client_cert:
                         type: string
-                      issuerURL:
-                        description: IssuerURL is used for the OIDC issuer URL. Only
-                          https URLs will be accepted.
-                        type: string
-                      usernameClaim:
-                        description: Optionally uses a custom claim for fetching the
-                          username. This defaults to "sub" if unset.
-                        type: string
-                      usernamePrefix:
-                        description: |-
-                          Optionally sets a custom username prefix. This defaults to "oidc:" if unset, which means a user called "user@example.com"
-                          on the OIDC side will be recognised as "oidc:user@example.com" in KCP.
+                      proxy_client_key:
                         type: string
                     required:
-                    - clientID
-                    - enabled
-                    - issuerURL
+                      - backend
+                      - backend_server_ca
+                      - path
+                      - proxy_client_cert
+                      - proxy_client_key
                     type: object
-                type: object
-              replicas:
-                description: 'Optional: Replicas configures the replica count for
-                  the front-proxy Deployment.'
-                format: int32
-                type: integer
-              rootShard:
-                description: RootShard configures the kcp root shard that this front-proxy
-                  instance should connect to.
-                properties:
-                  ref:
-                    description: Reference references a local RootShard object.
-                    properties:
-                      name:
-                        default: ""
-                        description: |-
-                          Name of the referent.
-                          This field is effectively required, but due to backwards compatibility is
-                          allowed to be empty. Instances of this type with an empty value here are
-                          almost certainly wrong.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                  type: array
+                auth:
+                  description: 'Optional: Auth configures various aspects of Authentication and Authorization for this front-proxy instance.'
+                  properties:
+                    dropGroups:
+                      description: 'Optional: DropGroups configures groups to be dropped before forwarding requests to Shards'
+                      items:
                         type: string
+                      type: array
+                    oidc:
+                      description: 'Optional: OIDC configures OpenID Connect Authentication.'
+                      properties:
+                        clientID:
+                          description: ClientID is the OIDC client ID configured on the issuer side for this KCP instance.
+                          type: string
+                        clientSecret:
+                          description: |-
+                            Optionally provide the client secret for the OIDC client. This is not used by KCP itself, but is used to generate
+                            a OIDC kubeconfig that can be shared with users to log in via the OIDC provider.
+                          type: string
+                        enabled:
+                          type: boolean
+                        groupsClaim:
+                          description: 'Experimental: Optionally provides a custom claim for fetching groups. The claim must be a string or an array of strings.'
+                          type: string
+                        groupsPrefix:
+                          description: |-
+                            Optionally sets a custom groups prefix. This defaults to "oidc:" if unset, which means a group called "group1"
+                            on the OIDC side will be recognised as "oidc:group1" in KCP.
+                          type: string
+                        issuerURL:
+                          description: IssuerURL is used for the OIDC issuer URL. Only https URLs will be accepted.
+                          type: string
+                        usernameClaim:
+                          description: Optionally uses a custom claim for fetching the username. This defaults to "sub" if unset.
+                          type: string
+                        usernamePrefix:
+                          description: |-
+                            Optionally sets a custom username prefix. This defaults to "oidc:" if unset, which means a user called "user@example.com"
+                            on the OIDC side will be recognised as "oidc:user@example.com" in KCP.
+                          type: string
+                      required:
+                        - clientID
+                        - enabled
+                        - issuerURL
+                      type: object
+                    passOnGroups:
+                      description: 'Optional: PassOnGroups configures groups to be passed on before forwarding requests to Shards'
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                certificateTemplates:
+                  additionalProperties:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a key value map to be copied to the target Certificate.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a key value map to be copied to the target Certificate.
+                            type: object
+                        type: object
+                      spec:
+                        properties:
+                          dnsNames:
+                            description: |-
+                              Requested DNS subject alternative names. The values given here will be merged into the
+                              DNS names determined automatically by the kcp-operator.
+                            items:
+                              type: string
+                            type: array
+                          duration:
+                            description: |-
+                              Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                              issuer may choose to ignore the requested duration, just like any other
+                              requested attribute.
+
+                              If unset, this defaults to 90 days.
+                              Minimum accepted duration is 1 hour.
+                              Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                            type: string
+                          ipAddresses:
+                            description: |-
+                              Requested IP address subject alternative names. The values given here will be merged into the
+                              DNS names determined automatically by the kcp-operator.
+                            items:
+                              type: string
+                            type: array
+                          privateKey:
+                            description: |-
+                              Private key options. These include the key algorithm and size, the used
+                              encoding and the rotation policy.
+                            properties:
+                              algorithm:
+                                description: |-
+                                  Algorithm is the private key algorithm of the corresponding private key
+                                  for this certificate.
+
+                                  If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                                  If `algorithm` is specified and `size` is not provided,
+                                  key size of 2048 will be used for `RSA` key algorithm and
+                                  key size of 256 will be used for `ECDSA` key algorithm.
+                                  key size is ignored when using the `Ed25519` key algorithm.
+                                enum:
+                                  - RSA
+                                  - ECDSA
+                                  - Ed25519
+                                type: string
+                              encoding:
+                                description: |-
+                                  The private key cryptography standards (PKCS) encoding for this
+                                  certificate's private key to be encoded in.
+
+                                  If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                                  and PKCS#8, respectively.
+                                  Defaults to `PKCS1` if not specified.
+                                enum:
+                                  - PKCS1
+                                  - PKCS8
+                                type: string
+                              rotationPolicy:
+                                description: |-
+                                  RotationPolicy controls how private keys should be regenerated when a
+                                  re-issuance is being processed.
+
+                                  If set to `Never`, a private key will only be generated if one does not
+                                  already exist in the target `spec.secretName`. If one does exist but it
+                                  does not have the correct algorithm or size, a warning will be raised
+                                  to await user intervention.
+                                  If set to `Always`, a private key matching the specified requirements
+                                  will be generated whenever a re-issuance occurs.
+                                  Default is `Never` for backward compatibility.
+                                enum:
+                                  - Never
+                                  - Always
+                                type: string
+                              size:
+                                description: |-
+                                  Size is the key bit size of the corresponding private key for this certificate.
+
+                                  If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                                  and will default to `2048` if not specified.
+                                  If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                                  and will default to `256` if not specified.
+                                  If `algorithm` is set to `Ed25519`, Size is ignored.
+                                  No other values are allowed.
+                                type: integer
+                            type: object
+                          renewBefore:
+                            description: |-
+                              How long before the currently issued certificate's expiry cert-manager should
+                              renew the certificate. For example, if a certificate is valid for 60 minutes,
+                              and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
+                              50 minutes after it was issued (i.e. when there are 10 minutes remaining until
+                              the certificate is no longer valid).
+
+                              NOTE: The actual lifetime of the issued certificate is used to determine the
+                              renewal time. If an issuer returns a certificate with a different lifetime than
+                              the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                              If unset, this defaults to 1/3 of the issued certificate's lifetime.
+                              Minimum accepted value is 5 minutes.
+                              Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                              Cannot be set if the `renewBeforePercentage` field is set.
+                            type: string
+                          secretTemplate:
+                            description: |-
+                              Defines annotations and labels to be copied to the Certificate's Secret.
+                              Labels and annotations on the Secret will be changed as they appear on the
+                              SecretTemplate when added or removed. SecretTemplate annotations are added
+                              in conjunction with, and cannot overwrite, the base set of annotations
+                              cert-manager sets on the Certificate's Secret.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                                type: object
+                            type: object
+                          subject:
+                            description: |-
+                              Requested set of X509 certificate subject attributes.
+                              More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                            properties:
+                              countries:
+                                description: Countries to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              localities:
+                                description: Cities to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              organizationalUnits:
+                                description: Organizational Units to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              organizations:
+                                description: Organizations to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              postalCodes:
+                                description: Postal codes to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              provinces:
+                                description: State/Provinces to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              serialNumber:
+                                description: Serial number to be used on the Certificate.
+                                type: string
+                              streetAddresses:
+                                description: Street addresses to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
                     type: object
-                    x-kubernetes-map-type: atomic
-                type: object
-            required:
-            - rootShard
-            type: object
-          status:
-            description: FrontProxyStatus defines the observed state of FrontProxy
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  description: |-
+                    CertificateTemplates allows to customize the properties on the generated
+                    certificates for this root shard.
+                  type: object
+                deploymentTemplate:
+                  description: 'Optional: DeploymentTemplate configures the Kubernetes Deployment created for this shard.'
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a key value map to be copied to the target Deployment.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels is a key value map to be copied to the target Deployment.
+                          type: object
+                      type: object
+                    spec:
+                      properties:
+                        template:
+                          description: Template describes the pods that will be created.
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a key value map to be copied to the Pod.
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: Labels is a key value map to be copied to the Pod.
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                affinity:
+                                  description: If specified, the pod's scheduling constraints
+                                  properties:
+                                    nodeAffinity:
+                                      description: Describes node affinity scheduling rules for the pod.
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            The scheduler will prefer to schedule pods to nodes that satisfy
+                                            the affinity expressions specified by this field, but it may choose
+                                            a node that violates one or more of the expressions. The node that is
+                                            most preferred is the one with the greatest sum of weights, i.e.
+                                            for each node that meets all of the scheduling requirements (resource
+                                            request, requiredDuringScheduling affinity expressions, etc.),
+                                            compute a sum by iterating through the elements of this field and adding
+                                            "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                            node(s) with the highest sum are the most preferred.
+                                          items:
+                                            description: |-
+                                              An empty preferred scheduling term matches all objects with implicit weight 0
+                                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                            properties:
+                                              preference:
+                                                description: A node selector term, associated with the corresponding weight.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector requirements by node's labels.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchFields:
+                                                    description: A list of node selector requirements by node's fields.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              weight:
+                                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - preference
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            If the affinity requirements specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled onto the node.
+                                            If the affinity requirements specified by this field cease to be met
+                                            at some point during pod execution (e.g. due to an update), the system
+                                            may or may not try to eventually evict the pod from its node.
+                                          properties:
+                                            nodeSelectorTerms:
+                                              description: Required. A list of node selector terms. The terms are ORed.
+                                              items:
+                                                description: |-
+                                                  A null or empty node selector term matches no objects. The requirements of
+                                                  them are ANDed.
+                                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector requirements by node's labels.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchFields:
+                                                    description: A list of node selector requirements by node's fields.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - nodeSelectorTerms
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    podAffinity:
+                                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            The scheduler will prefer to schedule pods to nodes that satisfy
+                                            the affinity expressions specified by this field, but it may choose
+                                            a node that violates one or more of the expressions. The node that is
+                                            most preferred is the one with the greatest sum of weights, i.e.
+                                            for each node that meets all of the scheduling requirements (resource
+                                            request, requiredDuringScheduling affinity expressions, etc.),
+                                            compute a sum by iterating through the elements of this field and adding
+                                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                            node(s) with the highest sum are the most preferred.
+                                          items:
+                                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              weight:
+                                                description: |-
+                                                  weight associated with matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - podAffinityTerm
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            If the affinity requirements specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled onto the node.
+                                            If the affinity requirements specified by this field cease to be met
+                                            at some point during pod execution (e.g. due to a pod label update), the
+                                            system may or may not try to eventually evict the pod from its node.
+                                            When there are multiple elements, the lists of nodes corresponding to each
+                                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                          items:
+                                            description: |-
+                                              Defines a set of pods (namely those matching the labelSelector
+                                              relative to the given namespace(s)) that this pod should be
+                                              co-located (affinity) or not co-located (anti-affinity) with,
+                                              where co-located is defined as running on a node whose value of
+                                              the label with key <topologyKey> matches that of any node on which
+                                              a pod of the set of pods is running
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                              - topologyKey
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    podAntiAffinity:
+                                      description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            The scheduler will prefer to schedule pods to nodes that satisfy
+                                            the anti-affinity expressions specified by this field, but it may choose
+                                            a node that violates one or more of the expressions. The node that is
+                                            most preferred is the one with the greatest sum of weights, i.e.
+                                            for each node that meets all of the scheduling requirements (resource
+                                            request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                            compute a sum by iterating through the elements of this field and adding
+                                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                            node(s) with the highest sum are the most preferred.
+                                          items:
+                                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              weight:
+                                                description: |-
+                                                  weight associated with matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - podAffinityTerm
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            If the anti-affinity requirements specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled onto the node.
+                                            If the anti-affinity requirements specified by this field cease to be met
+                                            at some point during pod execution (e.g. due to a pod label update), the
+                                            system may or may not try to eventually evict the pod from its node.
+                                            When there are multiple elements, the lists of nodes corresponding to each
+                                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                          items:
+                                            description: |-
+                                              Defines a set of pods (namely those matching the labelSelector
+                                              relative to the given namespace(s)) that this pod should be
+                                              co-located (affinity) or not co-located (anti-affinity) with,
+                                              where co-located is defined as running on a node whose value of
+                                              the label with key <topologyKey> matches that of any node on which
+                                              a pod of the set of pods is running
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                              - topologyKey
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                  type: object
+                                hostAliases:
+                                  description: |-
+                                    HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                    file if specified.
+                                  items:
+                                    description: |-
+                                      HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                      pod's hosts file.
+                                    properties:
+                                      hostnames:
+                                        description: Hostnames for the above IP address.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      ip:
+                                        description: IP address of the host file entry.
+                                        type: string
+                                    required:
+                                      - ip
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - ip
+                                  x-kubernetes-list-type: map
+                                imagePullSecrets:
+                                  description: |-
+                                    ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                    If specified, these secrets will be passed to individual puller implementations for them to use.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                  items:
+                                    description: |-
+                                      LocalObjectReference contains enough information to let you locate the
+                                      referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    NodeSelector is a selector which must be true for the pod to fit on a node.
+                                    Selector which must match a node's labels for the pod to be scheduled on that node.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                tolerations:
+                                  description: If specified, the pod's tolerations.
+                                  items:
+                                    description: |-
+                                      The pod this Toleration is attached to tolerates any taint that matches
+                                      the triple <key,value,effect> using the matching operator <operator>.
+                                    properties:
+                                      effect:
+                                        description: |-
+                                          Effect indicates the taint effect to match. Empty means match all taint effects.
+                                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                        type: string
+                                      key:
+                                        description: |-
+                                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Operator represents a key's relationship to the value.
+                                          Valid operators are Exists and Equal. Defaults to Equal.
+                                          Exists is equivalent to wildcard for value, so that a pod can
+                                          tolerate all taints of a particular category.
+                                        type: string
+                                      tolerationSeconds:
+                                        description: |-
+                                          TolerationSeconds represents the period of time the toleration (which must be
+                                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                          it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                          negative values will be treated as 0 (evict immediately) by the system.
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        description: |-
+                                          Value is the taint value the toleration matches to.
+                                          If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                        type: string
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                          type: object
+                      type: object
+                  type: object
+                externalHostname:
+                  description: 'Optional: ExternalHostname under which the FrontProxy can be reached. If empty, the RootShard''s external hostname will be used only.'
+                  type: string
+                image:
+                  description: 'Optional: Image defines the image to use. Defaults to the latest versioned image during the release of kcp-operator.'
+                  properties:
+                    imagePullSecrets:
+                      description: 'Optional: ImagePullSecrets is a list of secret references that should be used as image pull secrets (e.g. when a private registry is used).'
+                      items:
+                        description: |-
+                          LocalObjectReference contains enough information to let you locate the
+                          referenced object inside the same namespace.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    repository:
+                      description: Repository is the container image repository to use for KCP containers. Defaults to `ghcr.io/kcp-dev/kcp`.
+                      type: string
+                    tag:
+                      description: Tag is the container image tag to use for KCP containers. Defaults to the latest kcp release that the operator supports.
+                      type: string
+                  type: object
+                replicas:
+                  description: 'Optional: Replicas configures the replica count for the front-proxy Deployment.'
+                  format: int32
+                  type: integer
+                resources:
+                  description: Resources overrides the default resource requests and limits.
+                  properties:
+                    claims:
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+                        This is an alpha field and requires enabling the
+                        DynamicResourceAllocation feature gate.
+
+                        This field is immutable. It can only be set for containers.
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
+                            type: string
+                          request:
+                            description: |-
+                              Request is the name chosen for a request in the referenced claim.
+                              If empty, everything from the claim is made available, otherwise
+                              only the result of this request.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                  type: object
+                rootShard:
+                  description: RootShard configures the kcp root shard that this front-proxy instance should connect to.
+                  properties:
+                    ref:
+                      description: Reference references a local RootShard object.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                serviceTemplate:
+                  description: 'Optional: ServiceTemplate configures the Kubernetes Service created for this front-proxy instance.'
+                  properties:
+                    metadata:
+                      description: |-
+                        ServiceMetadataTemplate defines the default labels and annotations
+                        to be copied to the Kubernetes Service resource.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a key value map to be copied to the target Kubernetes Service.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels is a key value map to be copied to the target Kubernetes Service.
+                          type: object
+                      type: object
+                    spec:
+                      properties:
+                        clusterIP:
+                          type: string
+                        type:
+                          description: Service Type string describes ingress methods for a service
+                          type: string
+                      type: object
+                  type: object
+              required:
+                - rootShard
+              type: object
+            status:
+              description: FrontProxyStatus defines the observed state of FrontProxy
+              properties:
+                conditions:
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                phase:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -258,128 +1675,308 @@ spec:
     singular: kubeconfig
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Kubeconfig is the Schema for the kubeconfigs API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: KubeconfigSpec defines the desired state of Kubeconfig.
-            properties:
-              groups:
-                description: Username defines the groups embedded in the TLS certificate
-                  generated for this kubeconfig.
-                items:
-                  type: string
-                type: array
-              secretRef:
-                description: SecretRef defines the v1.Secret object that the resulting
-                  kubeconfig should be written to.
-                properties:
-                  name:
-                    default: ""
-                    description: |-
-                      Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Kubeconfig is the Schema for the kubeconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubeconfigSpec defines the desired state of Kubeconfig.
+              properties:
+                certificateTemplate:
+                  description: |-
+                    CertificateTemplate allows to customize the properties on the generated
+                    certificate for this kubeconfig.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a key value map to be copied to the target Certificate.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels is a key value map to be copied to the target Certificate.
+                          type: object
+                      type: object
+                    spec:
+                      properties:
+                        dnsNames:
+                          description: |-
+                            Requested DNS subject alternative names. The values given here will be merged into the
+                            DNS names determined automatically by the kcp-operator.
+                          items:
+                            type: string
+                          type: array
+                        duration:
+                          description: |-
+                            Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                            issuer may choose to ignore the requested duration, just like any other
+                            requested attribute.
+
+                            If unset, this defaults to 90 days.
+                            Minimum accepted duration is 1 hour.
+                            Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                          type: string
+                        ipAddresses:
+                          description: |-
+                            Requested IP address subject alternative names. The values given here will be merged into the
+                            DNS names determined automatically by the kcp-operator.
+                          items:
+                            type: string
+                          type: array
+                        privateKey:
+                          description: |-
+                            Private key options. These include the key algorithm and size, the used
+                            encoding and the rotation policy.
+                          properties:
+                            algorithm:
+                              description: |-
+                                Algorithm is the private key algorithm of the corresponding private key
+                                for this certificate.
+
+                                If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                                If `algorithm` is specified and `size` is not provided,
+                                key size of 2048 will be used for `RSA` key algorithm and
+                                key size of 256 will be used for `ECDSA` key algorithm.
+                                key size is ignored when using the `Ed25519` key algorithm.
+                              enum:
+                                - RSA
+                                - ECDSA
+                                - Ed25519
+                              type: string
+                            encoding:
+                              description: |-
+                                The private key cryptography standards (PKCS) encoding for this
+                                certificate's private key to be encoded in.
+
+                                If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                                and PKCS#8, respectively.
+                                Defaults to `PKCS1` if not specified.
+                              enum:
+                                - PKCS1
+                                - PKCS8
+                              type: string
+                            rotationPolicy:
+                              description: |-
+                                RotationPolicy controls how private keys should be regenerated when a
+                                re-issuance is being processed.
+
+                                If set to `Never`, a private key will only be generated if one does not
+                                already exist in the target `spec.secretName`. If one does exist but it
+                                does not have the correct algorithm or size, a warning will be raised
+                                to await user intervention.
+                                If set to `Always`, a private key matching the specified requirements
+                                will be generated whenever a re-issuance occurs.
+                                Default is `Never` for backward compatibility.
+                              enum:
+                                - Never
+                                - Always
+                              type: string
+                            size:
+                              description: |-
+                                Size is the key bit size of the corresponding private key for this certificate.
+
+                                If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                                and will default to `2048` if not specified.
+                                If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                                and will default to `256` if not specified.
+                                If `algorithm` is set to `Ed25519`, Size is ignored.
+                                No other values are allowed.
+                              type: integer
+                          type: object
+                        renewBefore:
+                          description: |-
+                            How long before the currently issued certificate's expiry cert-manager should
+                            renew the certificate. For example, if a certificate is valid for 60 minutes,
+                            and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
+                            50 minutes after it was issued (i.e. when there are 10 minutes remaining until
+                            the certificate is no longer valid).
+
+                            NOTE: The actual lifetime of the issued certificate is used to determine the
+                            renewal time. If an issuer returns a certificate with a different lifetime than
+                            the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                            If unset, this defaults to 1/3 of the issued certificate's lifetime.
+                            Minimum accepted value is 5 minutes.
+                            Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                            Cannot be set if the `renewBeforePercentage` field is set.
+                          type: string
+                        secretTemplate:
+                          description: |-
+                            Defines annotations and labels to be copied to the Certificate's Secret.
+                            Labels and annotations on the Secret will be changed as they appear on the
+                            SecretTemplate when added or removed. SecretTemplate annotations are added
+                            in conjunction with, and cannot overwrite, the base set of annotations
+                            cert-manager sets on the Certificate's Secret.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                              type: object
+                          type: object
+                        subject:
+                          description: |-
+                            Requested set of X509 certificate subject attributes.
+                            More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                          properties:
+                            countries:
+                              description: Countries to be used on the Certificate.
+                              items:
+                                type: string
+                              type: array
+                            localities:
+                              description: Cities to be used on the Certificate.
+                              items:
+                                type: string
+                              type: array
+                            organizationalUnits:
+                              description: Organizational Units to be used on the Certificate.
+                              items:
+                                type: string
+                              type: array
+                            organizations:
+                              description: Organizations to be used on the Certificate.
+                              items:
+                                type: string
+                              type: array
+                            postalCodes:
+                              description: Postal codes to be used on the Certificate.
+                              items:
+                                type: string
+                              type: array
+                            provinces:
+                              description: State/Provinces to be used on the Certificate.
+                              items:
+                                type: string
+                              type: array
+                            serialNumber:
+                              description: Serial number to be used on the Certificate.
+                              type: string
+                            streetAddresses:
+                              description: Street addresses to be used on the Certificate.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                groups:
+                  description: Username defines the groups embedded in the TLS certificate generated for this kubeconfig.
+                  items:
                     type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              target:
-                description: Target configures which kcp-operator object this kubeconfig
-                  should be generated for (shard or front-proxy).
-                properties:
-                  frontProxyRef:
-                    description: |-
-                      LocalObjectReference contains enough information to let you locate the
-                      referenced object inside the same namespace.
-                    properties:
-                      name:
-                        default: ""
-                        description: |-
-                          Name of the referent.
-                          This field is effectively required, but due to backwards compatibility is
-                          allowed to be empty. Instances of this type with an empty value here are
-                          almost certainly wrong.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        type: string
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  rootShardRef:
-                    description: |-
-                      LocalObjectReference contains enough information to let you locate the
-                      referenced object inside the same namespace.
-                    properties:
-                      name:
-                        default: ""
-                        description: |-
-                          Name of the referent.
-                          This field is effectively required, but due to backwards compatibility is
-                          allowed to be empty. Instances of this type with an empty value here are
-                          almost certainly wrong.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        type: string
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  shardRef:
-                    description: |-
-                      LocalObjectReference contains enough information to let you locate the
-                      referenced object inside the same namespace.
-                    properties:
-                      name:
-                        default: ""
-                        description: |-
-                          Name of the referent.
-                          This field is effectively required, but due to backwards compatibility is
-                          allowed to be empty. Instances of this type with an empty value here are
-                          almost certainly wrong.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        type: string
-                    type: object
-                    x-kubernetes-map-type: atomic
-                type: object
-              username:
-                description: Username defines the username embedded in the TLS certificate
-                  generated for this kubeconfig.
-                type: string
-              validity:
-                description: Validity configures the lifetime of the embedded TLS
-                  certificate. The kubeconfig secret will be automatically regenerated
-                  when the certificate expires.
-                type: string
-            required:
-            - secretRef
-            - target
-            - username
-            - validity
-            type: object
-          status:
-            description: KubeconfigStatus defines the observed state of Kubeconfig
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                secretRef:
+                  description: SecretRef defines the v1.Secret object that the resulting kubeconfig should be written to.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                target:
+                  description: Target configures which kcp-operator object this kubeconfig should be generated for (shard or front-proxy).
+                  properties:
+                    frontProxyRef:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    rootShardRef:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    shardRef:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                username:
+                  description: Username defines the username embedded in the TLS certificate generated for this kubeconfig.
+                  type: string
+                validity:
+                  description: Validity configures the lifetime of the embedded TLS certificate. The kubeconfig secret will be automatically regenerated when the certificate expires.
+                  type: string
+              required:
+                - secretRef
+                - target
+                - username
+                - validity
+              type: object
+            status:
+              description: KubeconfigStatus defines the observed state of Kubeconfig
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -396,155 +1993,346 @@ spec:
     singular: rootshard
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.external.hostname
-      name: Hostname
-      type: string
-    - jsonPath: .status.phase
-      name: Phase
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: RootShard is the Schema for the kcpinstances API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: RootShardSpec defines the desired state of RootShard.
-            properties:
-              cache:
-                description: Cache configures the cache server (with a Kubernetes-like
-                  API) used by a sharded kcp instance.
-                properties:
-                  embedded:
-                    description: Embedded configures settings for starting the cache
-                      server embedded in the root shard.
-                    properties:
-                      enabled:
-                        description: Enabled enables or disables running the cache
-                          server as embedded.
-                        type: boolean
-                    required:
-                    - enabled
-                    type: object
-                type: object
-              certificates:
-                properties:
-                  caSecretRef:
-                    description: |-
-                      LocalObjectReference contains enough information to let you locate the
-                      referenced object inside the same namespace.
-                    properties:
-                      name:
-                        default: ""
-                        description: |-
-                          Name of the referent.
-                          This field is effectively required, but due to backwards compatibility is
-                          allowed to be empty. Instances of this type with an empty value here are
-                          almost certainly wrong.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        type: string
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  issuerRef:
-                    description: ObjectReference is a reference to an object with
-                      a given name, kind and group.
-                    properties:
-                      group:
-                        description: Group of the object being referred to.
-                        type: string
-                      kind:
-                        description: Kind of the object being referred to.
-                        type: string
-                      name:
-                        description: Name of the object being referred to.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                type: object
-              clusterDomain:
-                type: string
-              etcd:
-                description: Etcd configures the etcd cluster that this shard should
-                  be using.
-                properties:
-                  endpoints:
-                    description: Endpoints is a list of http urls at which etcd nodes
-                      are available. The expected format is "https://etcd-hostname:2379".
-                    items:
-                      type: string
-                    type: array
-                  tlsConfig:
-                    description: ClientCert configures the client certificate used
-                      to access etcd.
-                    properties:
-                      secretRef:
-                        description: SecretRef is the reference to a v1.Secret object
-                          that contains the TLS certificate.
-                        properties:
-                          name:
-                            default: ""
-                            description: |-
-                              Name of the referent.
-                              This field is effectively required, but due to backwards compatibility is
-                              allowed to be empty. Instances of this type with an empty value here are
-                              almost certainly wrong.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+    - additionalPrinterColumns:
+        - jsonPath: .spec.external.hostname
+          name: Hostname
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: RootShard is the Schema for the kcpinstances API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RootShardSpec defines the desired state of RootShard.
+              properties:
+                audit:
+                  properties:
+                    webhook:
+                      properties:
+                        batchBufferSize:
+                          description: The size of the buffer to store events before batching and writing. Only used in batch mode.
+                          type: integer
+                        batchMaxSize:
+                          description: The maximum size of a batch. Only used in batch mode.
+                          type: integer
+                        batchMaxWait:
+                          description: |-
+                            The amount of time to wait before force writing the batch that hadn't reached the max size.
+                            Only used in batch mode.
+                          type: string
+                        batchThrottleBurst:
+                          description: |-
+                            Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before.
+                            Only used in batch mode.
+                          type: integer
+                        batchThrottleEnable:
+                          description: Whether batching throttling is enabled. Only used in batch mode.
+                          type: boolean
+                        batchThrottleQPS:
+                          description: |-
+                            Maximum average number of batches per second. Only used in batch mode.
+                            This value is a floating point number, stored as a string (e.g. "3.1").
+                          type: string
+                        configSecretName:
+                          description: |-
+                            Name of a Kubernetes Secret that contains a kubeconfig formatted file that defines the
+                            audit webhook configuration.
+                          type: string
+                        initialBackoff:
+                          description: The amount of time to wait before retrying the first failed request.
+                          type: string
+                        mode:
+                          description: |-
+                            Strategy for sending audit events. Blocking indicates sending events should block server
+                            responses. Batch causes the backend to buffer and write events asynchronously.
+                          enum:
+                            - ""
+                            - batch
+                            - blocking
+                            - blocking-strict
+                          type: string
+                        truncateEnabled:
+                          description: Whether event and batch truncating is enabled.
+                          type: boolean
+                        truncateMaxBatchSize:
+                          description: |-
+                            Maximum size of the batch sent to the underlying backend. Actual serialized size can be
+                            several hundreds of bytes greater. If a batch exceeds this limit, it is split into several
+                            batches of smaller size.
+                          type: integer
+                        truncateMaxEventSize:
+                          description: |-
+                            Maximum size of the audit event sent to the underlying backend. If the size of an event
+                            is greater than this number, first request and response are removed, and if this doesn't
+                            reduce the size enough, event is discarded.
+                          type: integer
+                        version:
+                          description: API group and version used for serializing audit events written to webhook.
+                          type: string
+                      type: object
+                  type: object
+                authorization:
+                  properties:
+                    webhook:
+                      properties:
+                        allowPaths:
+                          description: |-
+                            A list of HTTP paths to skip during authorization, i.e. these are authorized without contacting the 'core' kubernetes server.
+                            If specified, completely overwrites the default of [/healthz,/readyz,/livez].
+                          items:
                             type: string
+                          type: array
+                        cacheAuthorizedTTL:
+                          description: The duration to cache 'authorized' responses from the webhook authorizer.
+                          type: string
+                        cacheUnauthorizedTTL:
+                          description: The duration to cache 'unauthorized' responses from the webhook authorizer.
+                          type: string
+                        configSecretName:
+                          description: |-
+                            Name of a Kubernetes Secret that contains a kubeconfig formatted file that defines the
+                            authorization webhook configuration.
+                          type: string
+                        version:
+                          description: The API version of the authorization.k8s.io SubjectAccessReview to send to and expect from the webhook.
+                          type: string
+                      type: object
+                  type: object
+                cache:
+                  description: Cache configures the cache server (with a Kubernetes-like API) used by a sharded kcp instance.
+                  properties:
+                    embedded:
+                      description: Embedded configures settings for starting the cache server embedded in the root shard.
+                      properties:
+                        enabled:
+                          description: Enabled enables or disables running the cache server as embedded.
+                          type: boolean
+                      required:
+                        - enabled
+                      type: object
+                  type: object
+                certificateTemplates:
+                  additionalProperties:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a key value map to be copied to the target Certificate.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a key value map to be copied to the target Certificate.
+                            type: object
                         type: object
-                        x-kubernetes-map-type: atomic
-                    required:
-                    - secretRef
+                      spec:
+                        properties:
+                          dnsNames:
+                            description: |-
+                              Requested DNS subject alternative names. The values given here will be merged into the
+                              DNS names determined automatically by the kcp-operator.
+                            items:
+                              type: string
+                            type: array
+                          duration:
+                            description: |-
+                              Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                              issuer may choose to ignore the requested duration, just like any other
+                              requested attribute.
+
+                              If unset, this defaults to 90 days.
+                              Minimum accepted duration is 1 hour.
+                              Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                            type: string
+                          ipAddresses:
+                            description: |-
+                              Requested IP address subject alternative names. The values given here will be merged into the
+                              DNS names determined automatically by the kcp-operator.
+                            items:
+                              type: string
+                            type: array
+                          privateKey:
+                            description: |-
+                              Private key options. These include the key algorithm and size, the used
+                              encoding and the rotation policy.
+                            properties:
+                              algorithm:
+                                description: |-
+                                  Algorithm is the private key algorithm of the corresponding private key
+                                  for this certificate.
+
+                                  If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                                  If `algorithm` is specified and `size` is not provided,
+                                  key size of 2048 will be used for `RSA` key algorithm and
+                                  key size of 256 will be used for `ECDSA` key algorithm.
+                                  key size is ignored when using the `Ed25519` key algorithm.
+                                enum:
+                                  - RSA
+                                  - ECDSA
+                                  - Ed25519
+                                type: string
+                              encoding:
+                                description: |-
+                                  The private key cryptography standards (PKCS) encoding for this
+                                  certificate's private key to be encoded in.
+
+                                  If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                                  and PKCS#8, respectively.
+                                  Defaults to `PKCS1` if not specified.
+                                enum:
+                                  - PKCS1
+                                  - PKCS8
+                                type: string
+                              rotationPolicy:
+                                description: |-
+                                  RotationPolicy controls how private keys should be regenerated when a
+                                  re-issuance is being processed.
+
+                                  If set to `Never`, a private key will only be generated if one does not
+                                  already exist in the target `spec.secretName`. If one does exist but it
+                                  does not have the correct algorithm or size, a warning will be raised
+                                  to await user intervention.
+                                  If set to `Always`, a private key matching the specified requirements
+                                  will be generated whenever a re-issuance occurs.
+                                  Default is `Never` for backward compatibility.
+                                enum:
+                                  - Never
+                                  - Always
+                                type: string
+                              size:
+                                description: |-
+                                  Size is the key bit size of the corresponding private key for this certificate.
+
+                                  If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                                  and will default to `2048` if not specified.
+                                  If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                                  and will default to `256` if not specified.
+                                  If `algorithm` is set to `Ed25519`, Size is ignored.
+                                  No other values are allowed.
+                                type: integer
+                            type: object
+                          renewBefore:
+                            description: |-
+                              How long before the currently issued certificate's expiry cert-manager should
+                              renew the certificate. For example, if a certificate is valid for 60 minutes,
+                              and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
+                              50 minutes after it was issued (i.e. when there are 10 minutes remaining until
+                              the certificate is no longer valid).
+
+                              NOTE: The actual lifetime of the issued certificate is used to determine the
+                              renewal time. If an issuer returns a certificate with a different lifetime than
+                              the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                              If unset, this defaults to 1/3 of the issued certificate's lifetime.
+                              Minimum accepted value is 5 minutes.
+                              Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                              Cannot be set if the `renewBeforePercentage` field is set.
+                            type: string
+                          secretTemplate:
+                            description: |-
+                              Defines annotations and labels to be copied to the Certificate's Secret.
+                              Labels and annotations on the Secret will be changed as they appear on the
+                              SecretTemplate when added or removed. SecretTemplate annotations are added
+                              in conjunction with, and cannot overwrite, the base set of annotations
+                              cert-manager sets on the Certificate's Secret.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                                type: object
+                            type: object
+                          subject:
+                            description: |-
+                              Requested set of X509 certificate subject attributes.
+                              More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                            properties:
+                              countries:
+                                description: Countries to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              localities:
+                                description: Cities to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              organizationalUnits:
+                                description: Organizational Units to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              organizations:
+                                description: Organizations to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              postalCodes:
+                                description: Postal codes to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              provinces:
+                                description: State/Provinces to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              serialNumber:
+                                description: Serial number to be used on the Certificate.
+                                type: string
+                              streetAddresses:
+                                description: Street addresses to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
                     type: object
-                required:
-                - endpoints
-                type: object
-              external:
-                properties:
-                  hostname:
-                    description: |-
-                      Hostname is the external name of the kcp instance. This should be matched by a DNS
-                      record pointing to the kcp-front-proxy Service's external IP address.
-                    type: string
-                  port:
-                    format: int32
-                    type: integer
-                required:
-                - hostname
-                - port
-                type: object
-              image:
-                description: ImageSpec defines settings for using a specific image
-                  and overwriting the default images used.
-                properties:
-                  imagePullSecrets:
-                    description: 'Optional: ImagePullSecrets is a list of secret references
-                      that should be used as image pull secrets (e.g. when a private
-                      registry is used).'
-                    items:
+                  description: |-
+                    CertificateTemplates allows to customize the properties on the generated
+                    certificates for this root shard.
+                  type: object
+                certificates:
+                  description: |-
+                    Certificates configures how the operator should create the kcp root CA, from which it will
+                    then create all other sub CAs and leaf certificates.
+                  properties:
+                    caSecretRef:
                       description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
+                        CASecretRef can be used as an alternative to the IssuerRef: This field allows to configure
+                        a pre-existing CA certificate that should be used as sign kcp certificates.
+                        This Secret must contain both the certificate and the private key so that new sub certificates
+                        can be signed and created from this CA. This field is mutually exclusive with issuerRef.
                       properties:
                         name:
                           default: ""
@@ -557,97 +2345,1286 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
-                    type: array
-                  repository:
-                    description: Repository is the container image repository to use
-                      for KCP containers. Defaults to `ghcr.io/kcp-dev/kcp`.
-                    type: string
-                  tag:
-                    description: Tag is the container image tag to use for KCP containers.
-                      Defaults to the latest kcp release that the operator supports.
-                    type: string
-                type: object
-              replicas:
-                description: Replicas configures how many instances of this shard
-                  run in parallel. Defaults to 2 if not set.
-                format: int32
-                type: integer
-            required:
-            - cache
-            - certificates
-            - etcd
-            - external
-            type: object
-          status:
-            description: RootShardStatus defines the observed state of RootShard
-            properties:
-              conditions:
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
+                    issuerRef:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                        IssuerRef points to a pre-existing cert-manager Issuer or ClusterIssuer that shall be used
+                        to acquire new certificates. This field is mutually exclusive with caSecretRef.
+                      properties:
+                        group:
+                          description: Group of the object being referred to.
+                          type: string
+                        kind:
+                          description: Kind of the object being referred to.
+                          type: string
+                        name:
+                          description: Name of the object being referred to.
+                          type: string
+                      required:
+                        - name
+                      type: object
                   type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              phase:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                clusterDomain:
+                  type: string
+                deploymentTemplate:
+                  description: 'Optional: DeploymentTemplate configures the Kubernetes Deployment created for this shard.'
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a key value map to be copied to the target Deployment.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels is a key value map to be copied to the target Deployment.
+                          type: object
+                      type: object
+                    spec:
+                      properties:
+                        template:
+                          description: Template describes the pods that will be created.
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a key value map to be copied to the Pod.
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: Labels is a key value map to be copied to the Pod.
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                affinity:
+                                  description: If specified, the pod's scheduling constraints
+                                  properties:
+                                    nodeAffinity:
+                                      description: Describes node affinity scheduling rules for the pod.
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            The scheduler will prefer to schedule pods to nodes that satisfy
+                                            the affinity expressions specified by this field, but it may choose
+                                            a node that violates one or more of the expressions. The node that is
+                                            most preferred is the one with the greatest sum of weights, i.e.
+                                            for each node that meets all of the scheduling requirements (resource
+                                            request, requiredDuringScheduling affinity expressions, etc.),
+                                            compute a sum by iterating through the elements of this field and adding
+                                            "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                            node(s) with the highest sum are the most preferred.
+                                          items:
+                                            description: |-
+                                              An empty preferred scheduling term matches all objects with implicit weight 0
+                                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                            properties:
+                                              preference:
+                                                description: A node selector term, associated with the corresponding weight.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector requirements by node's labels.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchFields:
+                                                    description: A list of node selector requirements by node's fields.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              weight:
+                                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - preference
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            If the affinity requirements specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled onto the node.
+                                            If the affinity requirements specified by this field cease to be met
+                                            at some point during pod execution (e.g. due to an update), the system
+                                            may or may not try to eventually evict the pod from its node.
+                                          properties:
+                                            nodeSelectorTerms:
+                                              description: Required. A list of node selector terms. The terms are ORed.
+                                              items:
+                                                description: |-
+                                                  A null or empty node selector term matches no objects. The requirements of
+                                                  them are ANDed.
+                                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector requirements by node's labels.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchFields:
+                                                    description: A list of node selector requirements by node's fields.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - nodeSelectorTerms
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    podAffinity:
+                                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            The scheduler will prefer to schedule pods to nodes that satisfy
+                                            the affinity expressions specified by this field, but it may choose
+                                            a node that violates one or more of the expressions. The node that is
+                                            most preferred is the one with the greatest sum of weights, i.e.
+                                            for each node that meets all of the scheduling requirements (resource
+                                            request, requiredDuringScheduling affinity expressions, etc.),
+                                            compute a sum by iterating through the elements of this field and adding
+                                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                            node(s) with the highest sum are the most preferred.
+                                          items:
+                                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              weight:
+                                                description: |-
+                                                  weight associated with matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - podAffinityTerm
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            If the affinity requirements specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled onto the node.
+                                            If the affinity requirements specified by this field cease to be met
+                                            at some point during pod execution (e.g. due to a pod label update), the
+                                            system may or may not try to eventually evict the pod from its node.
+                                            When there are multiple elements, the lists of nodes corresponding to each
+                                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                          items:
+                                            description: |-
+                                              Defines a set of pods (namely those matching the labelSelector
+                                              relative to the given namespace(s)) that this pod should be
+                                              co-located (affinity) or not co-located (anti-affinity) with,
+                                              where co-located is defined as running on a node whose value of
+                                              the label with key <topologyKey> matches that of any node on which
+                                              a pod of the set of pods is running
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                              - topologyKey
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    podAntiAffinity:
+                                      description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            The scheduler will prefer to schedule pods to nodes that satisfy
+                                            the anti-affinity expressions specified by this field, but it may choose
+                                            a node that violates one or more of the expressions. The node that is
+                                            most preferred is the one with the greatest sum of weights, i.e.
+                                            for each node that meets all of the scheduling requirements (resource
+                                            request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                            compute a sum by iterating through the elements of this field and adding
+                                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                            node(s) with the highest sum are the most preferred.
+                                          items:
+                                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              weight:
+                                                description: |-
+                                                  weight associated with matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - podAffinityTerm
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            If the anti-affinity requirements specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled onto the node.
+                                            If the anti-affinity requirements specified by this field cease to be met
+                                            at some point during pod execution (e.g. due to a pod label update), the
+                                            system may or may not try to eventually evict the pod from its node.
+                                            When there are multiple elements, the lists of nodes corresponding to each
+                                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                          items:
+                                            description: |-
+                                              Defines a set of pods (namely those matching the labelSelector
+                                              relative to the given namespace(s)) that this pod should be
+                                              co-located (affinity) or not co-located (anti-affinity) with,
+                                              where co-located is defined as running on a node whose value of
+                                              the label with key <topologyKey> matches that of any node on which
+                                              a pod of the set of pods is running
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                              - topologyKey
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                  type: object
+                                hostAliases:
+                                  description: |-
+                                    HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                    file if specified.
+                                  items:
+                                    description: |-
+                                      HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                      pod's hosts file.
+                                    properties:
+                                      hostnames:
+                                        description: Hostnames for the above IP address.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      ip:
+                                        description: IP address of the host file entry.
+                                        type: string
+                                    required:
+                                      - ip
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - ip
+                                  x-kubernetes-list-type: map
+                                imagePullSecrets:
+                                  description: |-
+                                    ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                    If specified, these secrets will be passed to individual puller implementations for them to use.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                  items:
+                                    description: |-
+                                      LocalObjectReference contains enough information to let you locate the
+                                      referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    NodeSelector is a selector which must be true for the pod to fit on a node.
+                                    Selector which must match a node's labels for the pod to be scheduled on that node.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                tolerations:
+                                  description: If specified, the pod's tolerations.
+                                  items:
+                                    description: |-
+                                      The pod this Toleration is attached to tolerates any taint that matches
+                                      the triple <key,value,effect> using the matching operator <operator>.
+                                    properties:
+                                      effect:
+                                        description: |-
+                                          Effect indicates the taint effect to match. Empty means match all taint effects.
+                                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                        type: string
+                                      key:
+                                        description: |-
+                                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Operator represents a key's relationship to the value.
+                                          Valid operators are Exists and Equal. Defaults to Equal.
+                                          Exists is equivalent to wildcard for value, so that a pod can
+                                          tolerate all taints of a particular category.
+                                        type: string
+                                      tolerationSeconds:
+                                        description: |-
+                                          TolerationSeconds represents the period of time the toleration (which must be
+                                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                          it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                          negative values will be treated as 0 (evict immediately) by the system.
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        description: |-
+                                          Value is the taint value the toleration matches to.
+                                          If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                        type: string
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                          type: object
+                      type: object
+                  type: object
+                etcd:
+                  description: Etcd configures the etcd cluster that this shard should be using.
+                  properties:
+                    endpoints:
+                      description: Endpoints is a list of http urls at which etcd nodes are available. The expected format is "https://etcd-hostname:2379".
+                      items:
+                        type: string
+                      type: array
+                    tlsConfig:
+                      description: ClientCert configures the client certificate used to access etcd.
+                      properties:
+                        secretRef:
+                          description: SecretRef is the reference to a v1.Secret object that contains the TLS certificate.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - secretRef
+                      type: object
+                  required:
+                    - endpoints
+                  type: object
+                external:
+                  properties:
+                    hostname:
+                      description: |-
+                        Hostname is the external name of the kcp instance. This should be matched by a DNS
+                        record pointing to the kcp-front-proxy Service's external IP address.
+                      type: string
+                    port:
+                      format: int32
+                      type: integer
+                  required:
+                    - hostname
+                    - port
+                  type: object
+                image:
+                  description: ImageSpec defines settings for using a specific image and overwriting the default images used.
+                  properties:
+                    imagePullSecrets:
+                      description: 'Optional: ImagePullSecrets is a list of secret references that should be used as image pull secrets (e.g. when a private registry is used).'
+                      items:
+                        description: |-
+                          LocalObjectReference contains enough information to let you locate the
+                          referenced object inside the same namespace.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      type: array
+                    repository:
+                      description: Repository is the container image repository to use for KCP containers. Defaults to `ghcr.io/kcp-dev/kcp`.
+                      type: string
+                    tag:
+                      description: Tag is the container image tag to use for KCP containers. Defaults to the latest kcp release that the operator supports.
+                      type: string
+                  type: object
+                replicas:
+                  description: Replicas configures how many instances of this shard run in parallel. Defaults to 2 if not set.
+                  format: int32
+                  type: integer
+                resources:
+                  description: Resources overrides the default resource requests and limits.
+                  properties:
+                    claims:
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+                        This is an alpha field and requires enabling the
+                        DynamicResourceAllocation feature gate.
+
+                        This field is immutable. It can only be set for containers.
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
+                            type: string
+                          request:
+                            description: |-
+                              Request is the name chosen for a request in the referenced claim.
+                              If empty, everything from the claim is made available, otherwise
+                              only the result of this request.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                  type: object
+                serviceTemplate:
+                  description: 'Optional: ServiceTemplate configures the Kubernetes Service created for this shard.'
+                  properties:
+                    metadata:
+                      description: |-
+                        ServiceMetadataTemplate defines the default labels and annotations
+                        to be copied to the Kubernetes Service resource.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a key value map to be copied to the target Kubernetes Service.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels is a key value map to be copied to the target Kubernetes Service.
+                          type: object
+                      type: object
+                    spec:
+                      properties:
+                        clusterIP:
+                          type: string
+                        type:
+                          description: Service Type string describes ingress methods for a service
+                          type: string
+                      type: object
+                  type: object
+              required:
+                - cache
+                - certificates
+                - etcd
+                - external
+              type: object
+            status:
+              description: RootShardStatus defines the observed state of RootShard
+              properties:
+                conditions:
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                phase:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -664,50 +3641,1384 @@ spec:
     singular: shard
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Shard is the Schema for the shards API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ShardSpec defines the desired state of Shard
-            properties:
-              clusterDomain:
-                type: string
-              etcd:
-                description: Etcd configures the etcd cluster that this shard should
-                  be using.
-                properties:
-                  endpoints:
-                    description: Endpoints is a list of http urls at which etcd nodes
-                      are available. The expected format is "https://etcd-hostname:2379".
-                    items:
-                      type: string
-                    type: array
-                  tlsConfig:
-                    description: ClientCert configures the client certificate used
-                      to access etcd.
+    - additionalPrinterColumns:
+        - jsonPath: .spec.rootShard.ref.name
+          name: RootShard
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Shard is the Schema for the shards API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ShardSpec defines the desired state of Shard
+              properties:
+                audit:
+                  properties:
+                    webhook:
+                      properties:
+                        batchBufferSize:
+                          description: The size of the buffer to store events before batching and writing. Only used in batch mode.
+                          type: integer
+                        batchMaxSize:
+                          description: The maximum size of a batch. Only used in batch mode.
+                          type: integer
+                        batchMaxWait:
+                          description: |-
+                            The amount of time to wait before force writing the batch that hadn't reached the max size.
+                            Only used in batch mode.
+                          type: string
+                        batchThrottleBurst:
+                          description: |-
+                            Maximum number of requests sent at the same moment if ThrottleQPS was not utilized before.
+                            Only used in batch mode.
+                          type: integer
+                        batchThrottleEnable:
+                          description: Whether batching throttling is enabled. Only used in batch mode.
+                          type: boolean
+                        batchThrottleQPS:
+                          description: |-
+                            Maximum average number of batches per second. Only used in batch mode.
+                            This value is a floating point number, stored as a string (e.g. "3.1").
+                          type: string
+                        configSecretName:
+                          description: |-
+                            Name of a Kubernetes Secret that contains a kubeconfig formatted file that defines the
+                            audit webhook configuration.
+                          type: string
+                        initialBackoff:
+                          description: The amount of time to wait before retrying the first failed request.
+                          type: string
+                        mode:
+                          description: |-
+                            Strategy for sending audit events. Blocking indicates sending events should block server
+                            responses. Batch causes the backend to buffer and write events asynchronously.
+                          enum:
+                            - ""
+                            - batch
+                            - blocking
+                            - blocking-strict
+                          type: string
+                        truncateEnabled:
+                          description: Whether event and batch truncating is enabled.
+                          type: boolean
+                        truncateMaxBatchSize:
+                          description: |-
+                            Maximum size of the batch sent to the underlying backend. Actual serialized size can be
+                            several hundreds of bytes greater. If a batch exceeds this limit, it is split into several
+                            batches of smaller size.
+                          type: integer
+                        truncateMaxEventSize:
+                          description: |-
+                            Maximum size of the audit event sent to the underlying backend. If the size of an event
+                            is greater than this number, first request and response are removed, and if this doesn't
+                            reduce the size enough, event is discarded.
+                          type: integer
+                        version:
+                          description: API group and version used for serializing audit events written to webhook.
+                          type: string
+                      type: object
+                  type: object
+                authorization:
+                  properties:
+                    webhook:
+                      properties:
+                        allowPaths:
+                          description: |-
+                            A list of HTTP paths to skip during authorization, i.e. these are authorized without contacting the 'core' kubernetes server.
+                            If specified, completely overwrites the default of [/healthz,/readyz,/livez].
+                          items:
+                            type: string
+                          type: array
+                        cacheAuthorizedTTL:
+                          description: The duration to cache 'authorized' responses from the webhook authorizer.
+                          type: string
+                        cacheUnauthorizedTTL:
+                          description: The duration to cache 'unauthorized' responses from the webhook authorizer.
+                          type: string
+                        configSecretName:
+                          description: |-
+                            Name of a Kubernetes Secret that contains a kubeconfig formatted file that defines the
+                            authorization webhook configuration.
+                          type: string
+                        version:
+                          description: The API version of the authorization.k8s.io SubjectAccessReview to send to and expect from the webhook.
+                          type: string
+                      type: object
+                  type: object
+                certificateTemplates:
+                  additionalProperties:
                     properties:
-                      secretRef:
-                        description: SecretRef is the reference to a v1.Secret object
-                          that contains the TLS certificate.
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a key value map to be copied to the target Certificate.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a key value map to be copied to the target Certificate.
+                            type: object
+                        type: object
+                      spec:
+                        properties:
+                          dnsNames:
+                            description: |-
+                              Requested DNS subject alternative names. The values given here will be merged into the
+                              DNS names determined automatically by the kcp-operator.
+                            items:
+                              type: string
+                            type: array
+                          duration:
+                            description: |-
+                              Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                              issuer may choose to ignore the requested duration, just like any other
+                              requested attribute.
+
+                              If unset, this defaults to 90 days.
+                              Minimum accepted duration is 1 hour.
+                              Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                            type: string
+                          ipAddresses:
+                            description: |-
+                              Requested IP address subject alternative names. The values given here will be merged into the
+                              DNS names determined automatically by the kcp-operator.
+                            items:
+                              type: string
+                            type: array
+                          privateKey:
+                            description: |-
+                              Private key options. These include the key algorithm and size, the used
+                              encoding and the rotation policy.
+                            properties:
+                              algorithm:
+                                description: |-
+                                  Algorithm is the private key algorithm of the corresponding private key
+                                  for this certificate.
+
+                                  If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                                  If `algorithm` is specified and `size` is not provided,
+                                  key size of 2048 will be used for `RSA` key algorithm and
+                                  key size of 256 will be used for `ECDSA` key algorithm.
+                                  key size is ignored when using the `Ed25519` key algorithm.
+                                enum:
+                                  - RSA
+                                  - ECDSA
+                                  - Ed25519
+                                type: string
+                              encoding:
+                                description: |-
+                                  The private key cryptography standards (PKCS) encoding for this
+                                  certificate's private key to be encoded in.
+
+                                  If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                                  and PKCS#8, respectively.
+                                  Defaults to `PKCS1` if not specified.
+                                enum:
+                                  - PKCS1
+                                  - PKCS8
+                                type: string
+                              rotationPolicy:
+                                description: |-
+                                  RotationPolicy controls how private keys should be regenerated when a
+                                  re-issuance is being processed.
+
+                                  If set to `Never`, a private key will only be generated if one does not
+                                  already exist in the target `spec.secretName`. If one does exist but it
+                                  does not have the correct algorithm or size, a warning will be raised
+                                  to await user intervention.
+                                  If set to `Always`, a private key matching the specified requirements
+                                  will be generated whenever a re-issuance occurs.
+                                  Default is `Never` for backward compatibility.
+                                enum:
+                                  - Never
+                                  - Always
+                                type: string
+                              size:
+                                description: |-
+                                  Size is the key bit size of the corresponding private key for this certificate.
+
+                                  If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                                  and will default to `2048` if not specified.
+                                  If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                                  and will default to `256` if not specified.
+                                  If `algorithm` is set to `Ed25519`, Size is ignored.
+                                  No other values are allowed.
+                                type: integer
+                            type: object
+                          renewBefore:
+                            description: |-
+                              How long before the currently issued certificate's expiry cert-manager should
+                              renew the certificate. For example, if a certificate is valid for 60 minutes,
+                              and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
+                              50 minutes after it was issued (i.e. when there are 10 minutes remaining until
+                              the certificate is no longer valid).
+
+                              NOTE: The actual lifetime of the issued certificate is used to determine the
+                              renewal time. If an issuer returns a certificate with a different lifetime than
+                              the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                              If unset, this defaults to 1/3 of the issued certificate's lifetime.
+                              Minimum accepted value is 5 minutes.
+                              Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                              Cannot be set if the `renewBeforePercentage` field is set.
+                            type: string
+                          secretTemplate:
+                            description: |-
+                              Defines annotations and labels to be copied to the Certificate's Secret.
+                              Labels and annotations on the Secret will be changed as they appear on the
+                              SecretTemplate when added or removed. SecretTemplate annotations are added
+                              in conjunction with, and cannot overwrite, the base set of annotations
+                              cert-manager sets on the Certificate's Secret.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                                type: object
+                            type: object
+                          subject:
+                            description: |-
+                              Requested set of X509 certificate subject attributes.
+                              More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                            properties:
+                              countries:
+                                description: Countries to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              localities:
+                                description: Cities to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              organizationalUnits:
+                                description: Organizational Units to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              organizations:
+                                description: Organizations to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              postalCodes:
+                                description: Postal codes to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              provinces:
+                                description: State/Provinces to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                              serialNumber:
+                                description: Serial number to be used on the Certificate.
+                                type: string
+                              streetAddresses:
+                                description: Street addresses to be used on the Certificate.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                  description: |-
+                    CertificateTemplates allows to customize the properties on the generated
+                    certificates for this root shard.
+                  type: object
+                clusterDomain:
+                  type: string
+                deploymentTemplate:
+                  description: 'Optional: DeploymentTemplate configures the Kubernetes Deployment created for this shard.'
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a key value map to be copied to the target Deployment.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels is a key value map to be copied to the target Deployment.
+                          type: object
+                      type: object
+                    spec:
+                      properties:
+                        template:
+                          description: Template describes the pods that will be created.
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: Annotations is a key value map to be copied to the Pod.
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: Labels is a key value map to be copied to the Pod.
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                affinity:
+                                  description: If specified, the pod's scheduling constraints
+                                  properties:
+                                    nodeAffinity:
+                                      description: Describes node affinity scheduling rules for the pod.
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            The scheduler will prefer to schedule pods to nodes that satisfy
+                                            the affinity expressions specified by this field, but it may choose
+                                            a node that violates one or more of the expressions. The node that is
+                                            most preferred is the one with the greatest sum of weights, i.e.
+                                            for each node that meets all of the scheduling requirements (resource
+                                            request, requiredDuringScheduling affinity expressions, etc.),
+                                            compute a sum by iterating through the elements of this field and adding
+                                            "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                            node(s) with the highest sum are the most preferred.
+                                          items:
+                                            description: |-
+                                              An empty preferred scheduling term matches all objects with implicit weight 0
+                                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                            properties:
+                                              preference:
+                                                description: A node selector term, associated with the corresponding weight.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector requirements by node's labels.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchFields:
+                                                    description: A list of node selector requirements by node's fields.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              weight:
+                                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - preference
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            If the affinity requirements specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled onto the node.
+                                            If the affinity requirements specified by this field cease to be met
+                                            at some point during pod execution (e.g. due to an update), the system
+                                            may or may not try to eventually evict the pod from its node.
+                                          properties:
+                                            nodeSelectorTerms:
+                                              description: Required. A list of node selector terms. The terms are ORed.
+                                              items:
+                                                description: |-
+                                                  A null or empty node selector term matches no objects. The requirements of
+                                                  them are ANDed.
+                                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector requirements by node's labels.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchFields:
+                                                    description: A list of node selector requirements by node's fields.
+                                                    items:
+                                                      description: |-
+                                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                                        that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            Represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            An array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                                            array must have a single element, which will be interpreted as an integer.
+                                                            This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - nodeSelectorTerms
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    podAffinity:
+                                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            The scheduler will prefer to schedule pods to nodes that satisfy
+                                            the affinity expressions specified by this field, but it may choose
+                                            a node that violates one or more of the expressions. The node that is
+                                            most preferred is the one with the greatest sum of weights, i.e.
+                                            for each node that meets all of the scheduling requirements (resource
+                                            request, requiredDuringScheduling affinity expressions, etc.),
+                                            compute a sum by iterating through the elements of this field and adding
+                                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                            node(s) with the highest sum are the most preferred.
+                                          items:
+                                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              weight:
+                                                description: |-
+                                                  weight associated with matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - podAffinityTerm
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            If the affinity requirements specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled onto the node.
+                                            If the affinity requirements specified by this field cease to be met
+                                            at some point during pod execution (e.g. due to a pod label update), the
+                                            system may or may not try to eventually evict the pod from its node.
+                                            When there are multiple elements, the lists of nodes corresponding to each
+                                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                          items:
+                                            description: |-
+                                              Defines a set of pods (namely those matching the labelSelector
+                                              relative to the given namespace(s)) that this pod should be
+                                              co-located (affinity) or not co-located (anti-affinity) with,
+                                              where co-located is defined as running on a node whose value of
+                                              the label with key <topologyKey> matches that of any node on which
+                                              a pod of the set of pods is running
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                              - topologyKey
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    podAntiAffinity:
+                                      description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            The scheduler will prefer to schedule pods to nodes that satisfy
+                                            the anti-affinity expressions specified by this field, but it may choose
+                                            a node that violates one or more of the expressions. The node that is
+                                            most preferred is the one with the greatest sum of weights, i.e.
+                                            for each node that meets all of the scheduling requirements (resource
+                                            request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                            compute a sum by iterating through the elements of this field and adding
+                                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                            node(s) with the highest sum are the most preferred.
+                                          items:
+                                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity term, associated with the corresponding weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              weight:
+                                                description: |-
+                                                  weight associated with matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - podAffinityTerm
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: |-
+                                            If the anti-affinity requirements specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled onto the node.
+                                            If the anti-affinity requirements specified by this field cease to be met
+                                            at some point during pod execution (e.g. due to a pod label update), the
+                                            system may or may not try to eventually evict the pod from its node.
+                                            When there are multiple elements, the lists of nodes corresponding to each
+                                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                          items:
+                                            description: |-
+                                              Defines a set of pods (namely those matching the labelSelector
+                                              relative to the given namespace(s)) that this pod should be
+                                              co-located (affinity) or not co-located (anti-affinity) with,
+                                              where co-located is defined as running on a node whose value of
+                                              the label with key <topologyKey> matches that of any node on which
+                                              a pod of the set of pods is running
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                              - topologyKey
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                  type: object
+                                hostAliases:
+                                  description: |-
+                                    HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                    file if specified.
+                                  items:
+                                    description: |-
+                                      HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                      pod's hosts file.
+                                    properties:
+                                      hostnames:
+                                        description: Hostnames for the above IP address.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      ip:
+                                        description: IP address of the host file entry.
+                                        type: string
+                                    required:
+                                      - ip
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - ip
+                                  x-kubernetes-list-type: map
+                                imagePullSecrets:
+                                  description: |-
+                                    ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                    If specified, these secrets will be passed to individual puller implementations for them to use.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                  items:
+                                    description: |-
+                                      LocalObjectReference contains enough information to let you locate the
+                                      referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    NodeSelector is a selector which must be true for the pod to fit on a node.
+                                    Selector which must match a node's labels for the pod to be scheduled on that node.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                tolerations:
+                                  description: If specified, the pod's tolerations.
+                                  items:
+                                    description: |-
+                                      The pod this Toleration is attached to tolerates any taint that matches
+                                      the triple <key,value,effect> using the matching operator <operator>.
+                                    properties:
+                                      effect:
+                                        description: |-
+                                          Effect indicates the taint effect to match. Empty means match all taint effects.
+                                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                        type: string
+                                      key:
+                                        description: |-
+                                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Operator represents a key's relationship to the value.
+                                          Valid operators are Exists and Equal. Defaults to Equal.
+                                          Exists is equivalent to wildcard for value, so that a pod can
+                                          tolerate all taints of a particular category.
+                                        type: string
+                                      tolerationSeconds:
+                                        description: |-
+                                          TolerationSeconds represents the period of time the toleration (which must be
+                                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                          it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                          negative values will be treated as 0 (evict immediately) by the system.
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        description: |-
+                                          Value is the taint value the toleration matches to.
+                                          If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                        type: string
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                          type: object
+                      type: object
+                  type: object
+                etcd:
+                  description: Etcd configures the etcd cluster that this shard should be using.
+                  properties:
+                    endpoints:
+                      description: Endpoints is a list of http urls at which etcd nodes are available. The expected format is "https://etcd-hostname:2379".
+                      items:
+                        type: string
+                      type: array
+                    tlsConfig:
+                      description: ClientCert configures the client certificate used to access etcd.
+                      properties:
+                        secretRef:
+                          description: SecretRef is the reference to a v1.Secret object that contains the TLS certificate.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - secretRef
+                      type: object
+                  required:
+                    - endpoints
+                  type: object
+                image:
+                  description: ImageSpec defines settings for using a specific image and overwriting the default images used.
+                  properties:
+                    imagePullSecrets:
+                      description: 'Optional: ImagePullSecrets is a list of secret references that should be used as image pull secrets (e.g. when a private registry is used).'
+                      items:
+                        description: |-
+                          LocalObjectReference contains enough information to let you locate the
+                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
@@ -720,24 +5031,81 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
-                    required:
-                    - secretRef
-                    type: object
-                required:
-                - endpoints
-                type: object
-              image:
-                description: ImageSpec defines settings for using a specific image
-                  and overwriting the default images used.
-                properties:
-                  imagePullSecrets:
-                    description: 'Optional: ImagePullSecrets is a list of secret references
-                      that should be used as image pull secrets (e.g. when a private
-                      registry is used).'
-                    items:
+                      type: array
+                    repository:
+                      description: Repository is the container image repository to use for KCP containers. Defaults to `ghcr.io/kcp-dev/kcp`.
+                      type: string
+                    tag:
+                      description: Tag is the container image tag to use for KCP containers. Defaults to the latest kcp release that the operator supports.
+                      type: string
+                  type: object
+                replicas:
+                  description: Replicas configures how many instances of this shard run in parallel. Defaults to 2 if not set.
+                  format: int32
+                  type: integer
+                resources:
+                  description: Resources overrides the default resource requests and limits.
+                  properties:
+                    claims:
                       description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+
+                        This is an alpha field and requires enabling the
+                        DynamicResourceAllocation feature gate.
+
+                        This field is immutable. It can only be set for containers.
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
+                            type: string
+                          request:
+                            description: |-
+                              Request is the name chosen for a request in the referenced claim.
+                              If empty, everything from the claim is made available, otherwise
+                              only the result of this request.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      type: object
+                  type: object
+                rootShard:
+                  properties:
+                    ref:
+                      description: Reference references a local RootShard object.
                       properties:
                         name:
                           default: ""
@@ -750,48 +5118,106 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
-                    type: array
-                  repository:
-                    description: Repository is the container image repository to use
-                      for KCP containers. Defaults to `ghcr.io/kcp-dev/kcp`.
-                    type: string
-                  tag:
-                    description: Tag is the container image tag to use for KCP containers.
-                      Defaults to the latest kcp release that the operator supports.
-                    type: string
-                type: object
-              replicas:
-                description: Replicas configures how many instances of this shard
-                  run in parallel. Defaults to 2 if not set.
-                format: int32
-                type: integer
-              rootShard:
-                properties:
-                  ref:
-                    description: Reference references a local RootShard object.
+                  type: object
+                serviceTemplate:
+                  description: 'Optional: ServiceTemplate configures the Kubernetes Service created for this shard.'
+                  properties:
+                    metadata:
+                      description: |-
+                        ServiceMetadataTemplate defines the default labels and annotations
+                        to be copied to the Kubernetes Service resource.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a key value map to be copied to the target Kubernetes Service.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels is a key value map to be copied to the target Kubernetes Service.
+                          type: object
+                      type: object
+                    spec:
+                      properties:
+                        clusterIP:
+                          type: string
+                        type:
+                          description: Service Type string describes ingress methods for a service
+                          type: string
+                      type: object
+                  type: object
+              required:
+                - etcd
+                - rootShard
+              type: object
+            status:
+              description: ShardStatus defines the observed state of Shard
+              properties:
+                conditions:
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
-                      name:
-                        default: ""
+                      lastTransitionTime:
                         description: |-
-                          Name of the referent.
-                          This field is effectively required, but due to backwards compatibility is
-                          allowed to be empty. Instances of this type with an empty value here are
-                          almost certainly wrong.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
                         type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
                     type: object
-                    x-kubernetes-map-type: atomic
-                type: object
-            required:
-            - etcd
-            - rootShard
-            type: object
-          status:
-            description: ShardStatus defines the observed state of Shard
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                phase:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 {{- end }}


### PR DESCRIPTION
Forgot to update CRDs 🤦🏻 I will include a make target and maybe some validation, but for now this should do the trick.