### PR TITLE
Add kcp-operator to repository README and extend Chart README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The following charts are currently available from this repository:
 
 - [kcp](./charts/kcp/)
 - [api-syncagent](./charts/api-syncagent/)
+- [kcp-operator](./charts/kcp-operator/)
 
 > [!CAUTION]
 > The charts below are work-in-progress and currently not ready for production use.
@@ -19,7 +20,6 @@ that are meant to be used together:
 - [shard](./charts/shard/)
 - [proxy](./charts/proxy/)
 - [cache](./charts/cache/)
-
 
 ## Usage
 

--- a/charts/kcp-operator/README.md
+++ b/charts/kcp-operator/README.md
@@ -1,6 +1,33 @@
 # KCP Helm Chart - kcp-operator
 
 This Helm chart deploys an instance of the [kcp-operator](https://github.com/kcp-dev/kcp-operator).
-For more documentation, check out [docs.kcp.io/kcp-operator](https://docs.kcp.io/kcp-operator).
+
+## Requirements
+
+* [cert-manager](https://cert-manager.io/docs/installation)
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts. Please refer to Helm's
+[documentation](https://helm.sh/docs) to get started.
+
+Once Helm has been set up correctly, add the repo as follows:
+
+    helm repo add kcp https://kcp-dev.github.io/helm-charts
+
+If you had already added this repo earlier, run `helm repo update` to retrieve the latest versions
+of the packages. You can then run `helm search repo kcp` to see the charts.
+
+To install the kcp-operator chart (you can also pass custom values via `--values myvalues.yaml`):
+
+    helm install my-kcp-operator kcp/kcp-operator
+
+To uninstall the chart:
+
+    helm delete my-kcp-operator
 
 Check [values.yaml](./values.yaml) for configuration options for this Helm chart.
+
+## Documentation
+
+For documentation on how to use kcp-operator, check out [docs.kcp.io/kcp-operator](https://docs.kcp.io/kcp-operator).


### PR DESCRIPTION
Extending the kcp-operator README a bit and adding a reference from the main repository README.