### PR TITLE
kcp: require TLS passthrough for Ingress and improve README

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.10.2
+version: 0.11.0
 appVersion: "0.27.1"
 
 # optional metadata

--- a/charts/kcp/README.md
+++ b/charts/kcp/README.md
@@ -92,7 +92,7 @@ kcpFrontProxy:
     ingressClassName: "nginx" # use the ingress class of your ingress controller
 ```
 
-To facilitate tls passthrough, the default `values.yaml` include suitable annotations on the `Ingress` object for nginx-ingress-controller. If you are using another ingress controller, you might have to add additional annotations to enable TLS passthrough.
+To facilitate TLS passthrough, the default `values.yaml` includes suitable annotations on the `Ingress` object for nginx-ingress-controller. If you are using another ingress controller, you might have to add additional annotations to enable TLS passthrough.
 
 #### 3. OpenShift Route
 
@@ -130,8 +130,8 @@ To collect metrics from these targets, a `Prometheus` instance targetting those 
 
 ```yaml
 serviceMonitorSelector:
-    matchLabels:
-      app.kubernetes.io/name: kcp
+  matchLabels:
+    app.kubernetes.io/name: kcp
 ```
 
 ## PKI

--- a/charts/kcp/templates/front-proxy-certificates.yaml
+++ b/charts/kcp/templates/front-proxy-certificates.yaml
@@ -23,8 +23,9 @@ spec:
     - "{{ . }}"
     {{- end }}
   issuerRef:
-    {{- if .Values.kcpFrontProxy.certificateIssuer }}
-    {{ .Values.kcpFrontProxy.certificateIssuer | toYaml | nindent 4 }}
+    {{- if .Values.kcpFrontProxy.certificateIssuer.name }}
+    name: {{ .Values.kcpFrontProxy.certificateIssuer.name }}
+    kind: {{ .Values.kcpFrontProxy.certificateIssuer.kind | default "ClusterIssuer" }}
     {{- else }}
     name: {{ include "kcp.fullname" . }}-server-issuer
     kind: Issuer

--- a/charts/kcp/templates/letsencrypt-clusterissuers.yaml
+++ b/charts/kcp/templates/letsencrypt-clusterissuers.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: "pki"
 spec:
   acme:
-    email: {{ .Values.letsEncrypt.staging.email }}}
+    email: {{ .Values.letsEncrypt.staging.email }}
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # Secret resource that will be used to store the account's private key.

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -241,7 +241,7 @@ spec:
               mountPath: /etc/etcd/tls/client-ca
             - name: kcp-ca
               mountPath: /etc/kcp/tls/ca
-            {{- if and .Values.kcpFrontProxy.certificateIssuer .Values.kcpFrontProxy.certificateIssuer.secret }}
+            {{- if .Values.kcpFrontProxy.certificateIssuer.secret }}
             - name: kcp-front-proxy-ca
               mountPath: /etc/kcp-front-proxy/tls/ca
             {{- end}}
@@ -296,7 +296,7 @@ spec:
         - name: kcp-ca
           secret:
             secretName: {{ include "kcp.fullname" . }}-ca
-        {{- if and .Values.kcpFrontProxy.certificateIssuer .Values.kcpFrontProxy.certificateIssuer.secret }}
+        {{- if .Values.kcpFrontProxy.certificateIssuer.secret }}
         - name: kcp-front-proxy-ca
           secret:
             secretName: {{ required "kcpFrontProxy.certificateIssuer.secret.name is required" .Values.kcpFrontProxy.certificateIssuer.secret.name }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -149,10 +149,15 @@ kcpFrontProxy:
     enabled: false
     ingressClassName: ""
     annotations:
-      acme.cert-manager.io/http01-edit-in-place: "true"
       # this is ingress-controller-specific and might need configuration
       # depending on the ingress-controller in use.
       nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+      # kcp-front-proxy requires TLS passthrough from the ingress-controller
+      # so TLS client certificates are passed along. Note that this feature
+      # is disabled by default in nginx-ingress-controller and needs to be
+      # enabled: https://kubernetes.github.io/ingress-nginx/user-guide/tls/
+      # This will be different depending on the ingress-controller in use.
+      nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     secret: ""
   gateway:
     enabled: false
@@ -173,10 +178,10 @@ kcpFrontProxy:
     loadBalancerIP: ""
   # set this if you want kcp-front-proxy to use a specific certificate issuer
   # (e.g. the Let's Encrypt ones in this chart).
-  # certificateIssuer:
+  certificateIssuer: {}
   #   name: ""
   #   kind: Issuer
-  #   secret: # must be a Secret in the same namespace as KCP, containing the CA cert for the issuer
+  #   secret: # must be a Secret in the same namespace as KCP, containing the CA cert for the issuer.
   #     name: "" # the name of the Secret
   #     key: "" # the key in the Secret's data that contains the CA cert
   profiling:

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -6,12 +6,18 @@ global:
   # - name: "image-pull-secret"
   # or
   # - "image-pull-secret"
+
+# Required: DNS entry that will be mapped to kcp-front-proxy (see chart README for ingress methods).
 externalHostname: ""
-externalPort: "" # defaults to 8443 for .Values.kcpFrontProxy.service.type "LoadBalancer", 443 otherwise.
+# Port under which kcp-front-proxy will be accessible on the external hostname.
+# Defaults to 8443 for .Values.kcpFrontProxy.service.type "LoadBalancer", 443 otherwise.
+externalPort: "" 
+
 etcd:
   enabled: true
   image: quay.io/coreos/etcd
   tag: v3.5.15
+
   resources:
     requests:
       cpu: 500m
@@ -20,22 +26,28 @@ etcd:
       # cpu: 1
       memory: 20Gi
   volumeSize: 8Gi
+  
+  # StorageClass to use for etcd data volumes.
+  storageClassName: ""
+
   profiling:
     enabled: false
+
   monitoring:
     serviceMonitor:
       enabled: false
+
   podDisruptionBudget:
     enabled: false
     maxUnavailable: 1
-  storageClassName: ""
+
+  # When configured, this will add tolerations to the pods.
   tolerations: []
-   #When configured, this will add tolerations to the pods.
-   #tolerations:
-   #    - key: "kcp"
-   #      operator: "Equal"
-   #      value: "true"
-   #      effect: "NoSchedule"
+  #  - key: "kcp"
+  #    operator: "Equal"
+  #    value: "true"
+  #    effect: "NoSchedule"
+
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -48,20 +60,25 @@ etcd:
                   values:
                     - etcd
             topologyKey: "kubernetes.io/hostname"
+
 kcp:
   replicas: 1
   strategy:
     type: Recreate
   image: ghcr.io/kcp-dev/kcp
-  # set this to override the image tag used for kcp (determined by chart appVersion by default).
+  # Set this to override the image tag used for kcp (determined by chart appVersion by default).
   tag: ""
   pullPolicy: IfNotPresent
   v: "3"
+
   logicalClusterAdminFlag: true
   externalLogicalClusterAdminFlag: true
-  # enabled "batteries" (see kcp start --help for available batteries).
+  # Enabled "batteries" (see kcp start --help for available batteries).
   batteries:
     - workspace-types
+  # Additional flags passed to kcp binary.
+  extraFlags: []
+
   resources:
     requests:
       memory: 512Mi
@@ -69,10 +86,15 @@ kcp:
     limits:
       # cpu: 1
       memory: 20Gi
+
+  # StorageClass name used for audit data volume (if audit is set).
   volumeClassName: ""
+  volumeSize: 1Gi
+
   podAnnotations: {}
+
+  # Set this if you are using external etcds. Do not set serverAddress to "embedded", it is not supported.
   etcd:
-    # set this if you are using external etcds. Do not set this to "embedded", it is not supported.
     serverAddress: ""
     clientCertificate:
       # set this to a cert-manager Issuer that knows how to
@@ -80,11 +102,11 @@ kcp:
       # you are not using the etcd provided by this chart.
       issuer: ""
       commonName: root
-  volumeSize: 1Gi
-  extraFlags: []
+
   profiling:
     enabled: false
     port: 6060
+
   tokenAuth:
     enabled: false
     fileName: auth-token.csv
@@ -92,6 +114,7 @@ kcp:
         user-1-token,user-1,1111-1111-1111-1111,"team-1"
         admin-token,admin,5555-5555-5555-5555,"system:kcp:admin"
         system-token,system,6666-6666-6666-6666,"system:masters"
+
   authorization:
     webhook:
       # When configured, this Secret must contain a single key, "kubeconfig", containing
@@ -99,28 +122,34 @@ kcp:
       # See https://docs.kcp.io/kcp/main/concepts/authorization/authorizers/#webhook-authorizer
       # for more information.
       secretName: ""
+
   hostAliases:
     enabled: false
+
   homeWorkspaces:
     enabled: false
+
   securityContext:
-    # this matches the group id as set in the kcp Dockerfile.
+    # This matches the group id as set in the kcp Dockerfile.
     fsGroup: 65532
     seccompProfile:
       type: RuntimeDefault
+
   monitoring:
     serviceMonitor:
       enabled: false
+
   podDisruptionBudget:
     enabled: false
     minAvailable: 1
+
+  # When configured, this will add tolerations to the pods.
   tolerations: []
-   #When configured, this will add tolerations to the pods.
-   #tolerations:
-   #    - key: "kcp"
-   #      operator: "Equal"
-   #      value: "true"
-   #      effect: "NoSchedule"
+  #  - key: "kcp"
+  #    operator: "Equal"
+  #    value: "true"
+  #    effect: "NoSchedule"
+
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -133,23 +162,30 @@ kcp:
                   values:
                     - server
             topologyKey: "kubernetes.io/hostname"
+
 kcpFrontProxy:
   replicas: 1
   strategy:
     type: Recreate
   image: ghcr.io/kcp-dev/kcp
-  # set this to override the image tag used for kcp-front-proxy (determined by chart appVersion by default).
+  # Set this to override the image tag used for kcp-front-proxy (determined by chart appVersion by default).
   tag: ""
   pullPolicy: IfNotPresent
   v: "4"
+
   shardsKubeConfigFlag: true
+
+  # Additional flags passed to kcp-front-proxy binary.
+  extraFlags: []
+
   openshiftRoute:
     enabled: false
+
   ingress:
     enabled: false
     ingressClassName: ""
     annotations:
-      # this is ingress-controller-specific and might need configuration
+      # This is ingress-controller-specific and might need configuration
       # depending on the ingress-controller in use.
       nginx.ingress.kubernetes.io/backend-protocol: HTTPS
       # kcp-front-proxy requires TLS passthrough from the ingress-controller
@@ -159,24 +195,26 @@ kcpFrontProxy:
       # This will be different depending on the ingress-controller in use.
       nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     secret: ""
+
   gateway:
     enabled: false
     className: ""
   service:
     annotations: {}
-    # set this to LoadBalancer if you want to publish kcp-front-proxy
+    # Set this to LoadBalancer if you want to publish kcp-front-proxy
     # directly instead of going via Route/Ingress/Gateway resources.
     type: ClusterIP
-    # set this if you want to control the assigned node ports of the
+    # Set this if you want to control the assigned node ports of the
     # kcp-front-proxy Service (only applies if type is "NodePort" or "LoadBalancer")
     nodePort: ""
-    # set this if you want to control the assigned service IP for the kcp-front-proxy
+    # Set this if you want to control the assigned service IP for the kcp-front-proxy
     # service.
     clusterIP: ""
     # Pre-defined IP address of the kcp-front-proxy Service. (only applies if type is "LoadBalancer")
     # Used by cloud providers to connect the resulting load balancer service to a pre-existing static IP.
     loadBalancerIP: ""
-  # set this if you want kcp-front-proxy to use a specific certificate issuer
+
+  # Set this if you want kcp-front-proxy to use a specific certificate issuer
   # (e.g. the Let's Encrypt ones in this chart).
   certificateIssuer: {}
   #   name: ""
@@ -184,9 +222,11 @@ kcpFrontProxy:
   #   secret: # must be a Secret in the same namespace as KCP, containing the CA cert for the issuer.
   #     name: "" # the name of the Secret
   #     key: "" # the key in the Secret's data that contains the CA cert
+ 
   profiling:
     enabled: false
     port: 6060
+
   resources:
     requests:
       cpu: 100m
@@ -194,17 +234,22 @@ kcpFrontProxy:
     limits:
       # cpu: 1
       memory: 1Gi
+
   hostAliases:
     enabled: false
+
   securityContext:
     seccompProfile:
       type: RuntimeDefault
+
   monitoring:
     serviceMonitor:
       enabled: false
+
   podDisruptionBudget:
     enabled: false
     minAvailable: 1
+
   # The default virtual workspaces run in-process, but you can
   # extend the path mapping to include custom virtual workspaces
   # in the front-proxy's routing.
@@ -229,17 +274,18 @@ kcpFrontProxy:
   #     items:
   #       - key: ca.crt
   #         path: ca.crt
+
   extraVolumeMounts: []
   # - name: example-vw-serving-cert
   #   mountPath: /etc/example-vw-serving-cert
-  extraFlags: []
+
+  # When configured, this will add tolerations to the pods.
   tolerations: []
-   #When configured, this will add tolerations to the pods.
-   #tolerations:
-   #    - key: "kcp"
-   #      operator: "Equal"
-   #      value: "true"
-   #      effect: "NoSchedule"
+  #  - key: "kcp"
+  #    operator: "Equal"
+  #    value: "true"
+  #    effect: "NoSchedule"
+
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -273,13 +319,14 @@ oidc:
   # usernameClaim: "sub" # Same as --oidc-username-claim
   # usernamePrefix: "oidc:" # Same as --oidc-username-prefix
   caSecretName: ""
-  # assuming you're using cert-manager, you want to mount the CA certificate
+  # Assuming you're using cert-manager, you want to mount the CA certificate
   # directly and use its tls.crt key; if you instead mount a certificate that
   # is _signed by_ the OIDC CA, then do not use its ca.crt key, as it is the
   # absolute top root CA, the CA that actually signed the cert is one of the
   # certs in the tls.crt chain. As you cannot say "use this Secret, but the
   # second cert in the tls.crt key", it's easier to mount the CA cert secret.
   caSecretKeyName: "tls.crt"
+
 audit:
   enabled: false
   volumeSize: 1Gi
@@ -298,16 +345,18 @@ audit:
     maxSize: "250"
     maxBackup: "1"
     dir: /var/audit
+
 certificates:
   privateKeys:
     algorithm: RSA
     size: 2048
   subject: {}
-  # add additional dns names that should be embedded into the kcp server certificate.
+  # Add additional dns names that should be embedded into the kcp server certificate.
   dnsNames:
   - localhost
-  # additional ip addresses to be embedded in the etcd server and peer certs. Can be useful e.g. when using Istio you can pass "127.0.0.6" so the sidecar IP is included.
+  # Additional ip addresses to be embedded in the etcd server and peer certs. Can be useful e.g. when using Istio you can pass "127.0.0.6" so the sidecar IP is included.
   ipAddresses: []
+
 letsEncrypt:
   enabled: false
   staging:


### PR DESCRIPTION
Exposing kcp via `Ingress` only works with TLS passthrough, but this has neither been documented nor configured adequately in the default values. This PR addresses this and also fixes some templating issues as I've been trying to get Ingress + Let's Encrypt (a combination that seems to be chosen commonly) to work.

In addition, I've documented as much as I could regarding ingress method and Let's Encrypt certificates on kcp-front-proxy in an update to the README.md file for the chart.

_Also_, I took some time to add line breaks and some more comments to the `values.yaml` file, which makes it much more readable IMHO.