### PR TITLE
Remove Go runtime environment vars that pin resources to requests

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.11.0
+version: 0.11.1
 appVersion: "0.27.1"
 
 # optional metadata

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -196,14 +196,6 @@ spec:
               value: {{ required "A valid external hostname is required" .Values.externalHostname }}
             - name: EXTERNAL_PORT
               value: "{{ if eq .Values.externalPort "" }}{{ if eq .Values.kcpFrontProxy.service.type "LoadBalancer" }}8443{{ else }}443{{- end }}{{ else }}{{ .Values.externalPort }}{{- end }}"
-            - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  resource: requests.memory
-            - name: GOMAXPROCS
-              valueFrom:
-                resourceFieldRef:
-                  resource: requests.cpu
           livenessProbe:
             failureThreshold: 6
             httpGet:


### PR DESCRIPTION
We should remove these `GOMEMLIMIT` and `GOMAXPROCS` environment variables, they limit practical resource usage to what is in requests (so no ability to hit container resource limits). @xrstf investigated high CPU usage (which was the cause for #105) and it turns out that this happens when there are too many workspaces in kcp and there is simply the need for more memory than the process can take right now (3 MBs per empty workspace is the rough estimate of memory usage).