### PR TITLE
kcp: update to kcp 0.28.0

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.11.1
-appVersion: "0.27.1"
+version: 0.12.0
+appVersion: "0.28.0"
 
 # optional metadata
 type: application


### PR DESCRIPTION
This updates the `kcp` chart to use kcp [0.28.0](https://github.com/kcp-dev/kcp/releases/tag/v0.28.0).