### PR TITLE
Enable leader election by default and configure RollingUpdate

### DIFF
--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -188,6 +188,9 @@ spec:
             {{- if .Values.kcp.authorization.webhook.secretName }}
             - --authorization-webhook-config-file=/etc/kcp/authorization/webhook/kubeconfig
             {{- end }}
+            {{- if .Values.kcp.leaderElection.enabled }}
+            - --enable-leader-election
+            {{- end }}
             {{- range .Values.kcp.extraFlags }}
             - {{ . }}
             {{- end }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -64,7 +64,7 @@ etcd:
 kcp:
   replicas: 1
   strategy:
-    type: Recreate
+    type: RollingUpdate
   image: ghcr.io/kcp-dev/kcp
   # Set this to override the image tag used for kcp (determined by chart appVersion by default).
   tag: ""
@@ -76,6 +76,8 @@ kcp:
   # Enabled "batteries" (see kcp start --help for available batteries).
   batteries:
     - workspace-types
+  leaderElection:
+    enabled: true
   # Additional flags passed to kcp binary.
   extraFlags: []
 
@@ -166,7 +168,7 @@ kcp:
 kcpFrontProxy:
   replicas: 1
   strategy:
-    type: Recreate
+    type: RollingUpdate
   image: ghcr.io/kcp-dev/kcp
   # Set this to override the image tag used for kcp-front-proxy (determined by chart appVersion by default).
   tag: ""


### PR DESCRIPTION
This adds `kcp.leaderElection.enabled` to the available Helm chart values, which is set to `true` by default. Thus, we can enable rolling updates as kcp will now take a lock to determine whether it should start controllers or just serve API endpoints.

Closes #154.