### PR TITLE
feat: allow setting PriorityClassName on KCP components

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.12.0
+version: 0.12.1
 appVersion: "0.28.0"
 
 # optional metadata

--- a/charts/kcp/templates/etcd-statefulset.yaml
+++ b/charts/kcp/templates/etcd-statefulset.yaml
@@ -52,6 +52,9 @@ spec:
       imagePullSecrets:
         {{- include "kcp.imagePullSecrets" . | trim | nindent 8 }}
       {{- end }}
+      {{- with .Values.etcd.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: etcd
           image: {{ .Values.etcd.image }}:{{ .Values.etcd.tag }}

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -73,6 +73,9 @@ spec:
       imagePullSecrets:
         {{- include "kcp.imagePullSecrets" . | trim | nindent 8 }}
       {{- end }}
+      {{- with .Values.kcpFrontProxy.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: kcp-front-proxy
           image: "{{ .Values.kcpFrontProxy.image }}:{{- include "frontproxy.version" . }}"

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -110,6 +110,9 @@ spec:
       imagePullSecrets:
         {{- include "kcp.imagePullSecrets" . | trim | nindent 8 }}
       {{- end }}
+      {{- with .Values.kcp.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: kcp
           image: {{ .Values.kcp.image }}:{{- include "kcp.version" . }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -48,6 +48,9 @@ etcd:
   #    value: "true"
   #    effect: "NoSchedule"
 
+  # When configured, this will set the priority class for etcd pods.
+  priorityClassName: ""
+
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -151,6 +154,9 @@ kcp:
   #    operator: "Equal"
   #    value: "true"
   #    effect: "NoSchedule"
+
+  # When configured, this will set the priority class for kcp server pods.
+  priorityClassName: ""
 
   affinity:
     podAntiAffinity:
@@ -287,6 +293,9 @@ kcpFrontProxy:
   #    operator: "Equal"
   #    value: "true"
   #    effect: "NoSchedule"
+
+  # When configured, this will set the priority class for kcp-front-proxy pods.
+  priorityClassName: ""
 
   affinity:
     podAntiAffinity:


### PR DESCRIPTION
This PR adds support for setting PriorityClassName on KCP components.

### Testing

used `helm template` to ensure it renders the appropriate objects with and without PriorityClassName.