### PR TITLE
kcp: update to app version 0.28.1

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.12.2
-appVersion: "0.28.0"
+version: 0.12.3
+appVersion: "0.28.1"
 
 # optional metadata
 type: application


### PR DESCRIPTION
kcp 0.28.1 is out, so let's update the chart accordingly.

Full changelog available here: https://github.com/kcp-dev/kcp/releases/tag/v0.28.1