### PR TITLE
Switch from .local to .test tld for examples

### DIFF
--- a/charts/certificates/values.yaml
+++ b/charts/certificates/values.yaml
@@ -1,5 +1,5 @@
 fullnameOverride: alpha
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 
 certificates:
   name: certs
@@ -33,7 +33,7 @@ certificates:
   subject: {}
   # add additional dns names that should be embedded into the kcp server certificate.
   dnsNames:
-  - localhost
+    - localhost
 letsEncrypt:
   enabled: false
   staging:

--- a/examples/sharded/kind-values-phase2-alpha.yaml
+++ b/examples/sharded/kind-values-phase2-alpha.yaml
@@ -9,13 +9,13 @@
 #
 
 fullnameOverride: alpha
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 certificates:
   dnsNames:
-  - localhost
-  - alpha.kcp-alpha
-  - alpha.kcp-alpha.svc
-  - alpha.kcp-alpha.svc.cluster.local
+    - localhost
+    - alpha.kcp-alpha
+    - alpha.kcp-alpha.svc
+    - alpha.kcp-alpha.svc.cluster.local
   name: certs
   kcp:
     pki: false

--- a/examples/sharded/kind-values-phase2-beta.yaml
+++ b/examples/sharded/kind-values-phase2-beta.yaml
@@ -10,13 +10,13 @@
 
 fullnameOverride: beta
 # must be a valid DNS name for front proxy to work
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 certificates:
   dnsNames:
-  - localhost
-  - beta.kcp-beta
-  - beta.kcp-beta.svc
-  - beta.kcp-beta.svc.cluster.local
+    - localhost
+    - beta.kcp-beta
+    - beta.kcp-beta.svc
+    - beta.kcp-beta.svc.cluster.local
   name: certs
   kcp:
     pki: false

--- a/examples/sharded/kind-values-phase2-cache.yaml
+++ b/examples/sharded/kind-values-phase2-cache.yaml
@@ -10,13 +10,13 @@
 
 fullnameOverride: cache
 # must be a valid DNS name for front proxy to work
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 certificates:
   dnsNames:
-  - localhost
-  - cache-cache
-  - cache-cache.kcp-cache.svc
-  - cache-cache.kcp-cache.svc.cluster.local
+    - localhost
+    - cache-cache
+    - cache-cache.kcp-cache.svc
+    - cache-cache.kcp-cache.svc.cluster.local
   name: certs
   kcp:
     pki: false

--- a/examples/sharded/kind-values-phase2-proxy.yaml
+++ b/examples/sharded/kind-values-phase2-proxy.yaml
@@ -10,15 +10,15 @@
 
 fullnameOverride: proxy
 # must be a valid DNS name for front proxy to work
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 certificates:
-#  certificateIssuer:
-#     name: "kcp-letsencrypt-prod"
-#     name: "kcp-letsencrypt-staging"
-#     kind: ClusterIssuer
+  #  certificateIssuer:
+  #     name: "kcp-letsencrypt-prod"
+  #     name: "kcp-letsencrypt-staging"
+  #     kind: ClusterIssuer
   dnsNames:
-  - localhost
-  - kcp.dev.local
+    - localhost
+    - kcp.dev.test
   name: certs
   kcp:
     pki: false

--- a/examples/sharded/kind-values-phase3-alpha.yaml
+++ b/examples/sharded/kind-values-phase3-alpha.yaml
@@ -8,7 +8,7 @@
 #  alpha ./charts/kcp
 #
 fullnameOverride: alpha
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 etcd:
   enabled: true
 kcp:
@@ -22,7 +22,7 @@ kcp:
     - workspace-types
     - metrics-viewer
   extraFlags:
-  - --feature-gates=WorkspaceMounts=true
+    - --feature-gates=WorkspaceMounts=true
   homeWorkspaces:
     enabled: true
 externalCache:
@@ -33,7 +33,7 @@ sharding:
   isRoot: true
 caBundle:
   enabled: false
-  configMapName: kcp.dev.local
+  configMapName: kcp.dev.test
   configMapKey: root-certs.pem
 oidc:
   enabled: true

--- a/examples/sharded/kind-values-phase3-beta.yaml
+++ b/examples/sharded/kind-values-phase3-beta.yaml
@@ -8,7 +8,7 @@
 #  alpha ./charts/kcp
 #
 fullnameOverride: beta
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 etcd:
   enabled: true
 kcp:
@@ -21,7 +21,7 @@ kcp:
     - workspace-types
     - metrics-viewer
   extraFlags:
-  - --feature-gates=WorkspaceMounts=true
+    - --feature-gates=WorkspaceMounts=true
   homeWorkspaces:
     enabled: true
 externalCache:
@@ -33,7 +33,7 @@ sharding:
   rootShardInternalHostname: "alpha.kcp-alpha.svc.cluster.local"
 caBundle:
   enabled: false
-  configMapName: kcp.dev.local
+  configMapName: kcp.dev.test
   configMapKey: root-certs.pem
 oidc:
   enabled: true

--- a/examples/sharded/kind-values-phase3-cache.yaml
+++ b/examples/sharded/kind-values-phase3-cache.yaml
@@ -7,7 +7,7 @@
 #  alpha ./charts/kcp
 #
 fullnameOverride: cache
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 cache:
   enabled: true
   v: 8

--- a/examples/sharded/kind-values-phase3-proxy.yaml
+++ b/examples/sharded/kind-values-phase3-proxy.yaml
@@ -8,7 +8,7 @@
 #  alpha ./charts/kcp
 #
 fullnameOverride: proxy
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 etcd:
   enabled: false
 kcp:
@@ -37,7 +37,7 @@ sharding:
   rootShardInternalHostname: "alpha.kcp-alpha.svc.cluster.local"
 caBundle:
   enabled: false
-  configMapName: kcp.dev.local
+  configMapName: kcp.dev.test
   configMapKey: root-certs.pem
 oidc:
   enabled: true

--- a/hack/kind-values.yaml
+++ b/hack/kind-values.yaml
@@ -1,4 +1,4 @@
-externalHostname: "kcp.dev.local"
+externalHostname: "kcp.dev.test"
 externalPort: "8443"
 etcd:
   resources:
@@ -7,7 +7,7 @@ etcd:
 certificates:
   dnsNames:
     - localhost
-    - kcp.dev.local
+    - kcp.dev.test
 kcp:
   # tag is set via --set flag to make it more dynamic for testing purposes
   volumeClassName: "standard"
@@ -18,7 +18,7 @@ kcp:
     values:
       - ip: "10.96.0.100"
         hostnames:
-          - "kcp.dev.local"
+          - "kcp.dev.test"
 kcpFrontProxy:
   service:
     type: NodePort


### PR DESCRIPTION
`.local` is a reserved TLD declared in https://datatracker.ietf.org/doc/html/rfc6762. It will be resolved by the multicast DNS resolver on a hosts system and not the regular DNS resolver. On MacOS this leads to an issue, where the multicast resolver is primed to try to resolve it using IPv6, which fails after a 1 second timeout. Since multiple requests are being made, it waits for all of them to timeout, resulting in every request taking 5 seconds to complete. Here's a tcpdump to denote what I mean, see the timestamps:

```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on lo0, link-type NULL (BSD loopback), snapshot length 524288 bytes
16:57:51.243688 IP 127.0.0.1.5353 > 224.0.0.251.5353: 0 AAAA (QU)? kcp.dev.local. (31)
16:57:51.243765 IP6 fe80::1.5353 > ff02::fb.5353: 0 AAAA (QU)? kcp.dev.local. (31)
16:57:51.243831 IP 192.168.0.230.5353 > 224.0.0.251.5353: 0 AAAA (QU)? kcp.dev.local. (31)
16:57:51.243888 IP6 fe80::7f:3076:7eec:c592.5353 > ff02::fb.5353: 0 AAAA (QU)? kcp.dev.local. (31)
16:57:52.246684 IP 127.0.0.1.5353 > 224.0.0.251.5353: 0 AAAA (QM)? kcp.dev.local. (31)
16:57:52.246817 IP6 fe80::1.5353 > ff02::fb.5353: 0 AAAA (QM)? kcp.dev.local. (31)
16:57:52.246981 IP 192.168.0.230.5353 > 224.0.0.251.5353: 0 AAAA (QM)? kcp.dev.local. (31)
16:57:52.247108 IP6 fe80::7f:3076:7eec:c592.5353 > ff02::fb.5353: 0 AAAA (QM)? kcp.dev.local. (31)
16:57:55.253689 IP 127.0.0.1.5353 > 224.0.0.251.5353: 0 AAAA (QM)? kcp.dev.local. (31)
16:57:55.253822 IP6 fe80::1.5353 > ff02::fb.5353: 0 AAAA (QM)? kcp.dev.local. (31)
16:57:55.253978 IP 192.168.0.230.5353 > 224.0.0.251.5353: 0 AAAA (QM)? kcp.dev.local. (31)
16:57:55.254187 IP6 fe80::7f:3076:7eec:c592.5353 > ff02::fb.5353: 0 AAAA (QM)? kcp.dev.local. (31)
16:57:56.205698 IP 127.0.0.1.64904 > 127.0.0.1.8443: Flags [S], seq 3173511924, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 231838002 ecr 0,sackOK,eol], length 0
16:57:56.205825 IP 127.0.0.1.8443 > 127.0.0.1.64904: Flags [S.], seq 1355467873, ack 3173511925, win 65535, options [mss 16344,nop,wscale 6,nop,nop,TS val 2712207340 ecr 231838002,sackOK,eol], length 
```

While it is possible to work around this issue on MacOS by adding an IPv6 entry to /etc/hosts, I still don't like this approach as we would still send out multicast DNS requests every time you make a request to the local installation and we should not do this.

`.test` on the other hand is one of the reserved TLDs that can be used for any desired usage (https://datatracker.ietf.org/doc/html/rfc6761). I prefer this over choosing `.localhost`, another ietf free to use TLD as I don't want to know what kind of naming collisions we could run into there.