### PR TITLE
update api-syncagent chart for v0.4.0

### DIFF
--- a/charts/api-syncagent/Chart.yaml
+++ b/charts/api-syncagent/Chart.yaml
@@ -3,8 +3,8 @@ name: api-syncagent
 description: A Kubernetes agent to synchronize APIs and their objects between Kubernetes clusters and kcp.
 
 # version information
-version: 0.3.1
-appVersion: "v0.3.0"
+version: 0.4.0
+appVersion: "v0.4.0"
 
 # optional metadata
 type: application

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -33,7 +33,13 @@ spec:
           args:
             - --namespace=$(POD_NAMESPACE)
             - --enable-leader-election={{ .Values.enableLeaderElection }}
-            - --apiexport-ref=$(APIEXPORT_REF)
+            {{- with .Values.apiExportEndpointSliceName }}
+            - --apiexportendpointslice-ref={{ . }}
+            {{- else with .Values.apiExportName }}
+            - --apiexport-ref={{ . }}
+            {{- else }}
+            {{- required "Either an APIExportEndpointSliceRef or APIExportRef must be configured." "" }}
+            {{- end }}
             - --agent-name=$(AGENT_NAME)
             - --kcp-kubeconfig=/etc/api-syncagent/kcp/kubeconfig
             {{- with .Values.kubeconfig }}
@@ -60,8 +66,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-            - name: APIEXPORT_REF
-              value: '{{ required "APIExport name must be configured" .Values.apiExportName }}'
             - name: AGENT_NAME
               value: '{{ template "agentname" . }}'
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -90,7 +94,7 @@ spec:
       volumes:
         - name: kcp-kubeconfig
           secret:
-            secretName: '{{ required "Kubernetes Secret for the kcp kubeconfig must be configured" .Values.kcpKubeconfig }}'
+            secretName: '{{ required "Kubernetes Secret for the kcp kubeconfig must be configured." .Values.kcpKubeconfig }}'
         {{- with .Values.kubeconfig }}
         - name: cluster-kubeconfig
           secret:

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -7,15 +7,25 @@ global:
   # or
   # - "image-pull-secret"
 
-# Required: the name of the APIExport in kcp that this Sync Agent is supposed to serve.
-apiExportName: ""
+# Required: You need to configure a reference to an APIExportEndpointSlice so the
+# agent knows which API to serve and where to connect to. For kcp 0.27, you can
+# also instead configure an APIExport, but this is not recommended and could cause
+# issues when upgrading kcp.
+apiExportEndpointSliceName: ""
+
+# Alternatively: the name of the APIExport in kcp that this Sync Agent is supposed
+# to serve. Configuring an APIExportEndpointSlice instead is recommended and
+# futureproof.
+# apiExportName: ""
 
 # This Agent's public name, purely for informational purposes. If not set, defaults
 # to the Helm release name.
 agentName: ""
 
 # Required: Name of the Kubernetes Secret that contains a "kubeconfig" key,
-# with the kubeconfig provided by kcp to access it.
+# with the kubeconfig provided by kcp to access it. This kubeconfig must point
+# directly to the kcp cluster where the referenced object above
+# (APIExportEndpointSlice or APIExport) exist.
 kcpKubeconfig: ""
 
 # Optional: Name of a Kubernetes Secret that contains a "kubeconfig" key,


### PR DESCRIPTION
This adds support for the new --apiexportendpointslice-ref flag.