### PR TITLE
Update kcp-operator to 0.2.0

### DIFF
--- a/charts/kcp-operator/Chart.yaml
+++ b/charts/kcp-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp-operator
 description: A Helm chart for kcp-operator, a Kubernetes operator to deploy and manage kcp instances.
 
 # version information
-version: 0.1.1
-appVersion: "v0.1.0"
+version: 0.2.0
+appVersion: "v0.2.0"
 
 # optional metadata
 type: application

--- a/charts/kcp-operator/templates/crds.yaml
+++ b/charts/kcp-operator/templates/crds.yaml
@@ -188,16 +188,32 @@ spec:
                     type: object
                   type: array
                 auth:
-                  description: 'Optional: Auth configures various aspects of Authentication and Authorization for this front-proxy instance.'
+                  description: |-
+                    Optional: Auth configures various aspects of Authentication and Authorization for this front-proxy instance.
+                    If OIDC is enabled, it also requires enabling ServiceAccount authentication (as front-proxy will start validating JWT tokens, which includes ServiceAccount tokens).
                   properties:
                     dropGroups:
-                      description: 'Optional: DropGroups configures groups to be dropped before forwarding requests to Shards'
+                      description: 'Optional: DropGroups configures groups to be dropped before forwarding requests to Shards.'
                       items:
                         type: string
                       type: array
                     oidc:
                       description: 'Optional: OIDC configures OpenID Connect Authentication.'
                       properties:
+                        caFileRef:
+                          description: |-
+                            Optionally provides a reference to a secret that contains a CA bundle for the OIDC issuer. This is useful when
+                            the OIDC issuer is not publicly trusted.
+                          properties:
+                            key:
+                              description: Key is the key in the secret that contains the CA file. Defaults to "ca.crt".
+                              type: string
+                            name:
+                              description: Name is the name of the secret that contains the CA file.
+                              type: string
+                          required:
+                            - name
+                          type: object
                         clientID:
                           description: ClientID is the OIDC client ID configured on the issuer side for this KCP instance.
                           type: string
@@ -206,8 +222,6 @@ spec:
                             Optionally provide the client secret for the OIDC client. This is not used by KCP itself, but is used to generate
                             a OIDC kubeconfig that can be shared with users to log in via the OIDC provider.
                           type: string
-                        enabled:
-                          type: boolean
                         groupsClaim:
                           description: 'Experimental: Optionally provides a custom claim for fetching groups. The claim must be a string or an array of strings.'
                           type: string
@@ -229,7 +243,6 @@ spec:
                           type: string
                       required:
                         - clientID
-                        - enabled
                         - issuerURL
                       type: object
                     passOnGroups:
@@ -237,7 +250,21 @@ spec:
                       items:
                         type: string
                       type: array
+                    serviceAccount:
+                      description: 'Optional: serviceAccountAuthentication configures ServiceAccount Authentication.'
+                      properties:
+                        enabled:
+                          description: |-
+                            Optional: Enabled enables or disables ServiceAccount Authentication.
+                            If set, it will mount every shard's service account certificate to the front-proxy.
+                          type: boolean
+                      required:
+                        - enabled
+                      type: object
                   type: object
+                  x-kubernetes-validations:
+                    - message: OIDC requires ServiceAccount auth to be enabled.
+                      rule: '!has(self.oidc) || (has(self.serviceAccount) && self.serviceAccount.enabled)'
                 certificateTemplates:
                   additionalProperties:
                     properties:
@@ -424,7 +451,7 @@ spec:
                     type: object
                   description: |-
                     CertificateTemplates allows to customize the properties on the generated
-                    certificates for this root shard.
+                    certificates for this front-proxy.
                   type: object
                 deploymentTemplate:
                   description: 'Optional: DeploymentTemplate configures the Kubernetes Deployment created for this shard.'
@@ -2094,6 +2121,79 @@ spec:
                           type: string
                       type: object
                   type: object
+                auth:
+                  description: 'Optional: Auth configures various aspects of Authentication and Authorization for this shard.'
+                  properties:
+                    dropGroups:
+                      description: 'Optional: DropGroups configures groups to be dropped before forwarding requests to Shards.'
+                      items:
+                        type: string
+                      type: array
+                    oidc:
+                      description: 'Optional: OIDC configures OpenID Connect Authentication.'
+                      properties:
+                        caFileRef:
+                          description: |-
+                            Optionally provides a reference to a secret that contains a CA bundle for the OIDC issuer. This is useful when
+                            the OIDC issuer is not publicly trusted.
+                          properties:
+                            key:
+                              description: Key is the key in the secret that contains the CA file. Defaults to "ca.crt".
+                              type: string
+                            name:
+                              description: Name is the name of the secret that contains the CA file.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        clientID:
+                          description: ClientID is the OIDC client ID configured on the issuer side for this KCP instance.
+                          type: string
+                        clientSecret:
+                          description: |-
+                            Optionally provide the client secret for the OIDC client. This is not used by KCP itself, but is used to generate
+                            a OIDC kubeconfig that can be shared with users to log in via the OIDC provider.
+                          type: string
+                        groupsClaim:
+                          description: 'Experimental: Optionally provides a custom claim for fetching groups. The claim must be a string or an array of strings.'
+                          type: string
+                        groupsPrefix:
+                          description: |-
+                            Optionally sets a custom groups prefix. This defaults to "oidc:" if unset, which means a group called "group1"
+                            on the OIDC side will be recognised as "oidc:group1" in KCP.
+                          type: string
+                        issuerURL:
+                          description: IssuerURL is used for the OIDC issuer URL. Only https URLs will be accepted.
+                          type: string
+                        usernameClaim:
+                          description: Optionally uses a custom claim for fetching the username. This defaults to "sub" if unset.
+                          type: string
+                        usernamePrefix:
+                          description: |-
+                            Optionally sets a custom username prefix. This defaults to "oidc:" if unset, which means a user called "user@example.com"
+                            on the OIDC side will be recognised as "oidc:user@example.com" in KCP.
+                          type: string
+                      required:
+                        - clientID
+                        - issuerURL
+                      type: object
+                    passOnGroups:
+                      description: 'Optional: PassOnGroups configures groups to be passed on before forwarding requests to Shards'
+                      items:
+                        type: string
+                      type: array
+                    serviceAccount:
+                      description: 'Optional: serviceAccountAuthentication configures ServiceAccount Authentication.'
+                      properties:
+                        enabled:
+                          description: |-
+                            Optional: Enabled enables or disables ServiceAccount Authentication.
+                            If set, it will mount every shard's service account certificate to the front-proxy.
+                          type: boolean
+                      required:
+                        - enabled
+                      type: object
+                  type: object
                 authorization:
                   properties:
                     webhook:
@@ -2320,7 +2420,7 @@ spec:
                     type: object
                   description: |-
                     CertificateTemplates allows to customize the properties on the generated
-                    certificates for this root shard.
+                    certificates for this shard.
                   type: object
                 certificates:
                   description: |-
@@ -3459,6 +3559,1341 @@ spec:
                       description: Tag is the container image tag to use for KCP containers. Defaults to the latest kcp release that the operator supports.
                       type: string
                   type: object
+                proxy:
+                  description: |-
+                    Proxy configures the internal front-proxy that is only (supposed to be) used by the kcp-operator
+                    to manage all shards belonging to a root shard instance. No external traffic should ever be
+                    routed through this proxy, use a dedicated FrontProxy for that purpose.
+                  properties:
+                    certificateTemplates:
+                      additionalProperties:
+                        properties:
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a key value map to be copied to the target Certificate.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a key value map to be copied to the target Certificate.
+                                type: object
+                            type: object
+                          spec:
+                            properties:
+                              dnsNames:
+                                description: |-
+                                  Requested DNS subject alternative names. The values given here will be merged into the
+                                  DNS names determined automatically by the kcp-operator.
+                                items:
+                                  type: string
+                                type: array
+                              duration:
+                                description: |-
+                                  Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                                  issuer may choose to ignore the requested duration, just like any other
+                                  requested attribute.
+
+                                  If unset, this defaults to 90 days.
+                                  Minimum accepted duration is 1 hour.
+                                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                                type: string
+                              ipAddresses:
+                                description: |-
+                                  Requested IP address subject alternative names. The values given here will be merged into the
+                                  DNS names determined automatically by the kcp-operator.
+                                items:
+                                  type: string
+                                type: array
+                              privateKey:
+                                description: |-
+                                  Private key options. These include the key algorithm and size, the used
+                                  encoding and the rotation policy.
+                                properties:
+                                  algorithm:
+                                    description: |-
+                                      Algorithm is the private key algorithm of the corresponding private key
+                                      for this certificate.
+
+                                      If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                                      If `algorithm` is specified and `size` is not provided,
+                                      key size of 2048 will be used for `RSA` key algorithm and
+                                      key size of 256 will be used for `ECDSA` key algorithm.
+                                      key size is ignored when using the `Ed25519` key algorithm.
+                                    enum:
+                                      - RSA
+                                      - ECDSA
+                                      - Ed25519
+                                    type: string
+                                  encoding:
+                                    description: |-
+                                      The private key cryptography standards (PKCS) encoding for this
+                                      certificate's private key to be encoded in.
+
+                                      If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                                      and PKCS#8, respectively.
+                                      Defaults to `PKCS1` if not specified.
+                                    enum:
+                                      - PKCS1
+                                      - PKCS8
+                                    type: string
+                                  rotationPolicy:
+                                    description: |-
+                                      RotationPolicy controls how private keys should be regenerated when a
+                                      re-issuance is being processed.
+
+                                      If set to `Never`, a private key will only be generated if one does not
+                                      already exist in the target `spec.secretName`. If one does exist but it
+                                      does not have the correct algorithm or size, a warning will be raised
+                                      to await user intervention.
+                                      If set to `Always`, a private key matching the specified requirements
+                                      will be generated whenever a re-issuance occurs.
+                                      Default is `Never` for backward compatibility.
+                                    enum:
+                                      - Never
+                                      - Always
+                                    type: string
+                                  size:
+                                    description: |-
+                                      Size is the key bit size of the corresponding private key for this certificate.
+
+                                      If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                                      and will default to `2048` if not specified.
+                                      If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                                      and will default to `256` if not specified.
+                                      If `algorithm` is set to `Ed25519`, Size is ignored.
+                                      No other values are allowed.
+                                    type: integer
+                                type: object
+                              renewBefore:
+                                description: |-
+                                  How long before the currently issued certificate's expiry cert-manager should
+                                  renew the certificate. For example, if a certificate is valid for 60 minutes,
+                                  and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
+                                  50 minutes after it was issued (i.e. when there are 10 minutes remaining until
+                                  the certificate is no longer valid).
+
+                                  NOTE: The actual lifetime of the issued certificate is used to determine the
+                                  renewal time. If an issuer returns a certificate with a different lifetime than
+                                  the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                                  If unset, this defaults to 1/3 of the issued certificate's lifetime.
+                                  Minimum accepted value is 5 minutes.
+                                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                                  Cannot be set if the `renewBeforePercentage` field is set.
+                                type: string
+                              secretTemplate:
+                                description: |-
+                                  Defines annotations and labels to be copied to the Certificate's Secret.
+                                  Labels and annotations on the Secret will be changed as they appear on the
+                                  SecretTemplate when added or removed. SecretTemplate annotations are added
+                                  in conjunction with, and cannot overwrite, the base set of annotations
+                                  cert-manager sets on the Certificate's Secret.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                                    type: object
+                                type: object
+                              subject:
+                                description: |-
+                                  Requested set of X509 certificate subject attributes.
+                                  More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                                properties:
+                                  countries:
+                                    description: Countries to be used on the Certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                  localities:
+                                    description: Cities to be used on the Certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                  organizationalUnits:
+                                    description: Organizational Units to be used on the Certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                  organizations:
+                                    description: Organizations to be used on the Certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                  postalCodes:
+                                    description: Postal codes to be used on the Certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                  provinces:
+                                    description: State/Provinces to be used on the Certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serialNumber:
+                                    description: Serial number to be used on the Certificate.
+                                    type: string
+                                  streetAddresses:
+                                    description: Street addresses to be used on the Certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                      description: |-
+                        CertificateTemplates allows to customize the properties on the generated
+                        certificates for this front-proxy.
+                      type: object
+                    deploymentTemplate:
+                      description: 'Optional: DeploymentTemplate configures the Kubernetes Deployment created for this proxy.'
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a key value map to be copied to the target Deployment.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels is a key value map to be copied to the target Deployment.
+                              type: object
+                          type: object
+                        spec:
+                          properties:
+                            template:
+                              description: Template describes the pods that will be created.
+                              properties:
+                                metadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations is a key value map to be copied to the Pod.
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Labels is a key value map to be copied to the Pod.
+                                      type: object
+                                  type: object
+                                spec:
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: |-
+                                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to an update), the system
+                                                may or may not try to eventually evict the pod from its node.
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  items:
+                                                    description: |-
+                                                      A null or empty node selector term matches no objects. The requirements of
+                                                      them are ANDed.
+                                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - nodeSelectorTerms
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the anti-affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the anti-affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the anti-affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                      type: object
+                                    hostAliases:
+                                      description: |-
+                                        HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                        file if specified.
+                                      items:
+                                        description: |-
+                                          HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                          pod's hosts file.
+                                        properties:
+                                          hostnames:
+                                            description: Hostnames for the above IP address.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          ip:
+                                            description: IP address of the host file entry.
+                                            type: string
+                                        required:
+                                          - ip
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - ip
+                                      x-kubernetes-list-type: map
+                                    imagePullSecrets:
+                                      description: |-
+                                        ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                        If specified, these secrets will be passed to individual puller implementations for them to use.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                      items:
+                                        description: |-
+                                          LocalObjectReference contains enough information to let you locate the
+                                          referenced object inside the same namespace.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        NodeSelector is a selector which must be true for the pod to fit on a node.
+                                        Selector which must match a node's labels for the pod to be scheduled on that node.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      items:
+                                        description: |-
+                                          The pod this Toleration is attached to tolerates any taint that matches
+                                          the triple <key,value,effect> using the matching operator <operator>.
+                                        properties:
+                                          effect:
+                                            description: |-
+                                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: |-
+                                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Operator represents a key's relationship to the value.
+                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Exists is equivalent to wildcard for value, so that a pod can
+                                              tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: |-
+                                              TolerationSeconds represents the period of time the toleration (which must be
+                                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                              negative values will be treated as 0 (evict immediately) by the system.
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            description: |-
+                                              Value is the taint value the toleration matches to.
+                                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    image:
+                      description: 'Optional: Image allows to override the container image used for this proxy.'
+                      properties:
+                        imagePullSecrets:
+                          description: 'Optional: ImagePullSecrets is a list of secret references that should be used as image pull secrets (e.g. when a private registry is used).'
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        repository:
+                          description: Repository is the container image repository to use for KCP containers. Defaults to `ghcr.io/kcp-dev/kcp`.
+                          type: string
+                        tag:
+                          description: Tag is the container image tag to use for KCP containers. Defaults to the latest kcp release that the operator supports.
+                          type: string
+                      type: object
+                    replicas:
+                      description: 'Optional: Replicas configures how many instances of this proxy run in parallel. Defaults to 2 if not set.'
+                      format: int32
+                      type: integer
+                    resources:
+                      description: 'Optional: Resources overrides the default resource requests and limits.'
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This is an alpha field and requires enabling the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    serviceTemplate:
+                      description: 'Optional: ServiceTemplate configures the Kubernetes Service created for this proxy.'
+                      properties:
+                        metadata:
+                          description: |-
+                            ServiceMetadataTemplate defines the default labels and annotations
+                            to be copied to the Kubernetes Service resource.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a key value map to be copied to the target Kubernetes Service.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels is a key value map to be copied to the target Kubernetes Service.
+                              type: object
+                          type: object
+                        spec:
+                          properties:
+                            clusterIP:
+                              type: string
+                            type:
+                              description: Service Type string describes ingress methods for a service
+                              type: string
+                          type: object
+                      type: object
+                  type: object
                 replicas:
                   description: Replicas configures how many instances of this shard run in parallel. Defaults to 2 if not set.
                   format: int32
@@ -3619,6 +5054,20 @@ spec:
                   x-kubernetes-list-type: map
                 phase:
                   type: string
+                shards:
+                  description: Shards is a list of shards that are currently registered with this root shard.
+                  items:
+                    properties:
+                      name:
+                        description: Name is the name of the shard.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
               type: object
           type: object
       served: true
@@ -3740,6 +5189,79 @@ spec:
                         version:
                           description: API group and version used for serializing audit events written to webhook.
                           type: string
+                      type: object
+                  type: object
+                auth:
+                  description: 'Optional: Auth configures various aspects of Authentication and Authorization for this shard.'
+                  properties:
+                    dropGroups:
+                      description: 'Optional: DropGroups configures groups to be dropped before forwarding requests to Shards.'
+                      items:
+                        type: string
+                      type: array
+                    oidc:
+                      description: 'Optional: OIDC configures OpenID Connect Authentication.'
+                      properties:
+                        caFileRef:
+                          description: |-
+                            Optionally provides a reference to a secret that contains a CA bundle for the OIDC issuer. This is useful when
+                            the OIDC issuer is not publicly trusted.
+                          properties:
+                            key:
+                              description: Key is the key in the secret that contains the CA file. Defaults to "ca.crt".
+                              type: string
+                            name:
+                              description: Name is the name of the secret that contains the CA file.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        clientID:
+                          description: ClientID is the OIDC client ID configured on the issuer side for this KCP instance.
+                          type: string
+                        clientSecret:
+                          description: |-
+                            Optionally provide the client secret for the OIDC client. This is not used by KCP itself, but is used to generate
+                            a OIDC kubeconfig that can be shared with users to log in via the OIDC provider.
+                          type: string
+                        groupsClaim:
+                          description: 'Experimental: Optionally provides a custom claim for fetching groups. The claim must be a string or an array of strings.'
+                          type: string
+                        groupsPrefix:
+                          description: |-
+                            Optionally sets a custom groups prefix. This defaults to "oidc:" if unset, which means a group called "group1"
+                            on the OIDC side will be recognised as "oidc:group1" in KCP.
+                          type: string
+                        issuerURL:
+                          description: IssuerURL is used for the OIDC issuer URL. Only https URLs will be accepted.
+                          type: string
+                        usernameClaim:
+                          description: Optionally uses a custom claim for fetching the username. This defaults to "sub" if unset.
+                          type: string
+                        usernamePrefix:
+                          description: |-
+                            Optionally sets a custom username prefix. This defaults to "oidc:" if unset, which means a user called "user@example.com"
+                            on the OIDC side will be recognised as "oidc:user@example.com" in KCP.
+                          type: string
+                      required:
+                        - clientID
+                        - issuerURL
+                      type: object
+                    passOnGroups:
+                      description: 'Optional: PassOnGroups configures groups to be passed on before forwarding requests to Shards'
+                      items:
+                        type: string
+                      type: array
+                    serviceAccount:
+                      description: 'Optional: serviceAccountAuthentication configures ServiceAccount Authentication.'
+                      properties:
+                        enabled:
+                          description: |-
+                            Optional: Enabled enables or disables ServiceAccount Authentication.
+                            If set, it will mount every shard's service account certificate to the front-proxy.
+                          type: boolean
+                      required:
+                        - enabled
                       type: object
                   type: object
                 authorization:
@@ -3955,7 +5477,7 @@ spec:
                     type: object
                   description: |-
                     CertificateTemplates allows to customize the properties on the generated
-                    certificates for this root shard.
+                    certificates for this shard.
                   type: object
                 clusterDomain:
                   type: string

--- a/charts/kcp-operator/templates/deployment.yaml
+++ b/charts/kcp-operator/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "kcp-operator.fullname" . }}
   labels:
     {{- include "kcp-operator.labels" . | nindent 4 }}
-  annotations: 
+  annotations:
     {{- .Values.annotations | toYaml | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -43,6 +43,9 @@ spec:
           args:
             - --metrics-bind-address=:8443
             - --leader-elect={{ .Values.leaderElection.enabled | default true }}
+            - --zap-log-level={{ .Values.logging.level }}
+            - --zap-encoder={{ .Values.logging.encoder }}
+            - --zap-time-encoding={{ .Values.logging.timeEncoding }}
           ports:
             - name: healthz
               containerPort: 8081

--- a/charts/kcp-operator/values.yaml
+++ b/charts/kcp-operator/values.yaml
@@ -28,6 +28,14 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
 
+logging:
+  # one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+  level: info
+  # one of 'json' or 'console'
+  encoder: json
+  # one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'
+  timeEncoding: iso8601
+
 # This is for the secretes for pulling an image from a private repository. More information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/.
 imagePullSecrets: []
 

--- a/hack/update-kcp-operator-crds.sh
+++ b/hack/update-kcp-operator-crds.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cd $(dirname $0)/..
+
+cd charts/kcp-operator/
+version="$(yq '.appVersion' Chart.yaml)"
+crdFile=templates/crds.yaml
+
+set -x
+
+echo "{{- if .Values.crds.create }}" > "$crdFile"
+kubectl kustomize "https://github.com/kcp-dev/kcp-operator/config/crd?ref=$version" | yq >> "$crdFile"
+echo "{{- end }}" >> "$crdFile"


### PR DESCRIPTION
This bumps the kcp-operator to the latest version and makes the logging configurable. This PR also changes the default time format from epoch to iso8601, because holy moly, logs with epoch timestamps are just useless to humans and I would bet every AI tooling out there understands ISO-8601 even better than a random large number that it would first have to identify as a unix timestamp.