### PR TITLE
kcp-operator: update to app version 0.2.1

### DIFF
--- a/charts/kcp-operator/Chart.yaml
+++ b/charts/kcp-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp-operator
 description: A Helm chart for kcp-operator, a Kubernetes operator to deploy and manage kcp instances.
 
 # version information
-version: 0.2.0
-appVersion: "v0.2.0"
+version: 0.2.1
+appVersion: "v0.2.1"
 
 # optional metadata
 type: application


### PR DESCRIPTION
New kcp version means new kcp-operator version, and that is 0.2.1. It bumps kcp to 0.28.3 by default.