### PR TITLE
api-syncagent: bump to 0.4.1

### DIFF
--- a/charts/api-syncagent/Chart.yaml
+++ b/charts/api-syncagent/Chart.yaml
@@ -3,8 +3,8 @@ name: api-syncagent
 description: A Kubernetes agent to synchronize APIs and their objects between Kubernetes clusters and kcp.
 
 # version information
-version: 0.4.0
-appVersion: "v0.4.0"
+version: 0.4.1
+appVersion: "v0.4.1"
 
 # optional metadata
 type: application


### PR DESCRIPTION
Bumps api-syncagent to [v0.4.1](https://github.com/kcp-dev/api-syncagent/releases/tag/v0.4.1). This release includes an important fix for syncing more than one `PublishedResource`'s objects.