### PR TITLE
Add/fix support for hostAliases in all Helm charts

### DIFF
--- a/charts/api-syncagent/Chart.yaml
+++ b/charts/api-syncagent/Chart.yaml
@@ -3,7 +3,7 @@ name: api-syncagent
 description: A Kubernetes agent to synchronize APIs and their objects between Kubernetes clusters and kcp.
 
 # version information
-version: 0.4.2
+version: 0.4.3
 appVersion: "v0.4.2"
 
 # optional metadata

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -75,6 +75,10 @@ spec:
             capabilities:
               drop:
                 - ALL
+          {{- if .Values.hostAliases.enabled }}
+          hostAliases:
+            {{- toYaml .Values.hostAliases.values | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: kcp-kubeconfig
               mountPath: /etc/api-syncagent/kcp

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -87,3 +87,9 @@ extraVolumes: []
 extraVolumeMounts: []
 #  - name: extra-secret
 #    mountPath: /etc/test
+
+hostAliases:
+  enabled: false
+  values:
+    ip: ""
+    hostnames: []

--- a/charts/cache/Chart.yaml
+++ b/charts/cache/Chart.yaml
@@ -3,7 +3,7 @@ name: cache
 description: A cache server for prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.0.4
+version: 0.0.5
 appVersion: "0.22.0"
 
 # optional metadata

--- a/charts/cache/templates/cache-deployment.yaml
+++ b/charts/cache/templates/cache-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       {{- if .Values.cache.hostAliases.enabled }}
       hostAliases:
-        {{- toYaml .Values.cache.hostAliases.values | nindent 6 }}
+        {{- toYaml .Values.cache.hostAliases.values | nindent 8 }}
       {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cache/values.yaml
+++ b/charts/cache/values.yaml
@@ -28,10 +28,10 @@ cache:
       # cpu: 1
       memory: 1Gi
   hostAliases:
-    enabled: true
+    enabled: false
     values:
-      ip: "foo"
-      hostnames: ["kcp.api.portal.dev.local"]
+      ip: ""
+      hostnames: []
   securityContext:
     seccompProfile:
       type: RuntimeDefault

--- a/charts/cache/values.yaml
+++ b/charts/cache/values.yaml
@@ -28,7 +28,10 @@ cache:
       # cpu: 1
       memory: 1Gi
   hostAliases:
-    enabled: false
+    enabled: true
+    values:
+      ip: "foo"
+      hostnames: ["kcp.api.portal.dev.local"]
   securityContext:
     seccompProfile:
       type: RuntimeDefault

--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.12.5
+version: 0.12.6
 appVersion: "0.28.3"
 
 # optional metadata

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -62,7 +62,7 @@ spec:
       {{- end }}
       {{- if .Values.kcpFrontProxy.hostAliases.enabled }}
       hostAliases:
-        {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 6 }}
+        {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 8 }}
       {{- end }}
       {{- with .Values.kcpFrontProxy.affinity}}
       affinity:

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -96,7 +96,7 @@ spec:
       {{- end }}
       {{- if .Values.kcp.hostAliases.enabled }}
       hostAliases:
-        {{- toYaml .Values.kcp.hostAliases.values | nindent 6 }}
+        {{- toYaml .Values.kcp.hostAliases.values | nindent 8 }}
       {{- end }}
       {{- with .Values.kcp.affinity}}
       affinity:

--- a/charts/proxy/Chart.yaml
+++ b/charts/proxy/Chart.yaml
@@ -3,7 +3,7 @@ name: proxy
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.0.3
+version: 0.0.4
 appVersion: "0.22.0"
 
 # optional metadata

--- a/charts/proxy/templates/front-proxy-deployment.yaml
+++ b/charts/proxy/templates/front-proxy-deployment.yaml
@@ -70,7 +70,7 @@ spec:
       {{- end }}
       {{- if .Values.kcpFrontProxy.hostAliases.enabled }}
       hostAliases:
-        {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 6 }}
+        {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 8 }}
       {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/shard/Chart.yaml
+++ b/charts/shard/Chart.yaml
@@ -3,7 +3,7 @@ name: shard
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.0.3
+version: 0.0.4
 appVersion: "0.22.0"
 
 # optional metadata

--- a/charts/shard/templates/server-deployment.yaml
+++ b/charts/shard/templates/server-deployment.yaml
@@ -106,7 +106,7 @@ spec:
       {{- end }}
       {{- if .Values.kcp.hostAliases.enabled }}
       hostAliases:
-        {{- toYaml .Values.kcp.hostAliases.values | nindent 6 }}
+        {{- toYaml .Values.kcp.hostAliases.values | nindent 8 }}
       {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
This PR started out just wanting to add hostAliases support to the syncagent chart, but then I noticed that all other charts have the YAML wrongly indented, so now this PR also fixes the alias support in them, too.