### PR TITLE
fix indentation in api-syncagent Helm chart

### DIFF
--- a/charts/api-syncagent/Chart.yaml
+++ b/charts/api-syncagent/Chart.yaml
@@ -3,7 +3,7 @@ name: api-syncagent
 description: A Kubernetes agent to synchronize APIs and their objects between Kubernetes clusters and kcp.
 
 # version information
-version: 0.4.3
+version: 0.4.4
 appVersion: "v0.4.2"
 
 # optional metadata

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       imagePullSecrets:
         {{- include "imagePullSecrets" . | trim | nindent 8 }}
       {{- end }}
+      {{- if .Values.hostAliases.enabled }}
+      hostAliases:
+        {{- toYaml .Values.hostAliases.values | nindent 8 }}
+      {{- end }}
       containers:
         - name: agent
           args:
@@ -75,10 +79,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-          {{- if .Values.hostAliases.enabled }}
-          hostAliases:
-            {{- toYaml .Values.hostAliases.values | nindent 12 }}
-          {{- end }}
           volumeMounts:
             - name: kcp-kubeconfig
               mountPath: /etc/api-syncagent/kcp


### PR DESCRIPTION
I made a mistake in #176.