### PR TITLE
update kcp Helm chart to kcp 0.29.0

### DIFF
--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -3,8 +3,8 @@ name: kcp
 description: A prototype of a multi-tenant Kubernetes control plane for workloads on many clusters
 
 # version information
-version: 0.12.8
-appVersion: "0.28.3"
+version: 0.13.0
+appVersion: "0.29.0"
 
 # optional metadata
 type: application


### PR DESCRIPTION
It's been overdue. 0.30 was released this week, so it's high time we catch up to it. My idea is to have one 0.29 release for the Helm charts and not just directly jump from 0.28 to 0.30.