### PR TITLE
add artifacthub verification file

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,1 @@
+repositoryID: ae5989db-e4a5-4fd2-82f6-20a2bed70ae2


### PR DESCRIPTION
This ensures that our ArtifactHub repo is shown as verified, as per https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml