### PR TITLE
Add helm chart for init-agent

### DIFF
--- a/charts/init-agent/Chart.yaml
+++ b/charts/init-agent/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: init-agent
+description: A Kubernetes agent to initialize newly created workspaces with Kubernetes objects.
+
+# version information
+version: 0.1.0
+appVersion: "v0.1.0"
+
+# optional metadata
+type: application
+home: https://www.kcp.io/
+keywords:
+  - kcp
+  - kubernetes
+  - multitenancy
+  - controlplane
+sources:
+  - https://github.com/kcp-dev/helm-charts
+  - https://github.com/kcp-dev/init-agent
+icon: https://raw.githubusercontent.com/kcp-dev/kcp/main/contrib/logo/blue-green.svg

--- a/charts/init-agent/LICENSE
+++ b/charts/init-agent/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/init-agent/README.md
+++ b/charts/init-agent/README.md
@@ -1,0 +1,78 @@
+# KCP Helm Chart - Init Agent
+
+This Helm chart deploys an instance of the [Init Agent](https://github.com/kcp-dev/init-agent).
+
+## Mode of Operation
+
+The Init Agent connects to a variety of workspaces inside kcp. In each of them, the necessary
+RBAC needs to be provisioned for the agent to do its work.
+
+To accomplish this, this Helm chart can be configured to output three different sets of manifests,
+called **targets**:
+
+* `""` (default) – By default, the Helm chart will output the Deployment, ServiceAccount and RBAC to
+  run the Init Agent on a Kubernetes cluster. For this to work, you need to provide Helm with a
+  kubeconfig for that cluster.
+* `configcluster` – In this mode, the Helm chart outputs the RBAC necessary for the agent to read
+  and process its `InitTarget` objects. This is meant to be installed into the workspace that is
+  configured via `.configWorkspace` when installing the chart in default mode (above). This needs
+  to be done once, using a kubeconfig for Helm that points to the config workspace of choice in
+  kcp.
+* `wstcluster` – This mode outputs the necessary RBAC to read and initialize `WorkspaceTypes`. This
+  needs to be installed into each workspace where `WorkspaceType` objects exist that are referenced
+  by an `InitTarget`.For this to work, you need to provide Helm with a kubeconfig that points to
+  the effective workspace.
+
+To toggle between these, use the Helm variable `target`:
+
+```bash
+helm install init-agent kcp/init-agent \
+  --set "target=configcluster" \
+  --values myvalues.yaml
+```
+
+## Usage
+
+[Helm](https://helm.sh) must be installed to use the charts. Please refer to Helm's
+[documentation](https://helm.sh/docs) to get started.
+
+Once Helm has been set up correctly, add the repo as follows:
+
+```shell
+helm repo add kcp https://kcp-dev.github.io/helm-charts
+```
+
+If you had already added this repo earlier, run `helm repo update` to retrieve the latest versions
+of the packages. You can then run `helm search repo kcp` to see the charts.
+
+To install the kcp chart:
+
+```shell
+helm upgrade --install my-init-agent kcp/init-agent --values ./myvalues.yaml
+```
+
+**NB:** Remember to install the chart also into kcp. See [mode of operation](#mode-of-operation) above.
+
+To uninstall the release:
+
+```shell
+helm delete my-init-agent
+```
+
+## Configuration
+
+### kcp kubeconfig
+
+When installing the Init Agent, you need to provide it with the name of a Kubernetes Secret that
+contains a kubeconfig to communicate with kcp (using the `kcpKubeconfig` variable of this chart).
+
+Since the concrete way you choose to authenticate to kcp is up to you (the [kcp-operator](https://docs.kcp.io/kcp-operator/) for example relies on client certificates), and the Helm chart can configure RBAC,
+you need to configure in the Helm chart as what user the Init Agent is authenticated in kcp. The
+default configuration assumes that the user is named `kcp-init-agent`:
+
+```yaml
+configCluster:
+  rbacSubject:
+    kind: User
+    name: my-init-agent
+```

--- a/charts/init-agent/README.md
+++ b/charts/init-agent/README.md
@@ -1,4 +1,4 @@
-# KCP Helm Chart - Init Agent
+# kcp Helm Chart - Init Agent
 
 This Helm chart deploys an instance of the [Init Agent](https://github.com/kcp-dev/init-agent).
 

--- a/charts/init-agent/templates/_helpers.tpl
+++ b/charts/init-agent/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "name" -}}{{ .Release.Name }}{{- end }}
+{{- define "agentname" -}}{{ .Values.agentName | default .Release.Name }}{{- end }}
+
+{{- define "imagePullSecrets" -}}
+{{- range .Values.imagePullSecrets }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml . | trim }}
+{{- else }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/init-agent/templates/configcluster/crds.yaml
+++ b/charts/init-agent/templates/configcluster/crds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configCluster.crds.create }}
+{{- if and (has "configcluster" .Values.targets) .Values.configCluster.crds.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/init-agent/templates/configcluster/crds.yaml
+++ b/charts/init-agent/templates/configcluster/crds.yaml
@@ -1,0 +1,132 @@
+{{- if .Values.configCluster.crds.create }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: inittargets.initialization.kcp.io
+spec:
+  group: initialization.kcp.io
+  names:
+    kind: InitTarget
+    listKind: InitTargetList
+    plural: inittargets
+    singular: inittarget
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.workspaceTypeRef.path
+          name: WSType Cluster
+          type: string
+        - jsonPath: .spec.workspaceTypeRef.name
+          name: WSType
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                sources:
+                  items:
+                    properties:
+                      template:
+                        properties:
+                          name:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                    type: object
+                  type: array
+                workspaceTypeRef:
+                  properties:
+                    name:
+                      type: string
+                    path:
+                      type: string
+                  required:
+                    - name
+                    - path
+                  type: object
+              required:
+                - sources
+                - workspaceTypeRef
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: inittemplates.initialization.kcp.io
+spec:
+  group: initialization.kcp.io
+  names:
+    kind: InitTemplate
+    listKind: InitTemplateList
+    plural: inittemplates
+    singular: inittemplate
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                template:
+                  type: string
+              required:
+                - template
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+{{- end }}

--- a/charts/init-agent/templates/configcluster/rbac.yaml
+++ b/charts/init-agent/templates/configcluster/rbac.yaml
@@ -1,0 +1,104 @@
+{{- if eq .Values.target "configcluster" }}
+{{- if .Values.leaderElection.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: '{{ template "name" . }}:leaderelection'
+  namespace: '{{ .Values.leaderElection.namespace }}'
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ template "name" . }}:leaderelection'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ template "name" . }}:leaderelection'
+subjects:
+{{ list .Values.configCluster.rbacSubject | toYaml | indent 2 }}
+{{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ template "name" . }}:{{ .Release.Namespace }}'
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - syncagent.kcp.io
+    resources:
+      - publishedresources
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - syncagent.kcp.io
+    resources:
+      - publishedresources/status
+    verbs:
+      - create
+      - get
+      - update
+      - patch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: '{{ template "name" . }}:{{ .Release.Namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ template "name" . }}:{{ .Release.Namespace }}'
+subjects:
+{{ list .Values.configCluster.rbacSubject | toYaml | indent 2 }}
+{{- end }}

--- a/charts/init-agent/templates/configcluster/rbac.yaml
+++ b/charts/init-agent/templates/configcluster/rbac.yaml
@@ -38,56 +38,30 @@ kind: ClusterRole
 metadata:
   name: '{{ template "name" . }}:{{ .Release.Namespace }}'
 rules:
+  # provide access to this workspace
+  - verbs:
+      - access
+    nonResourceURLs:
+      - "/"
+
+  # allow to read the init-agent's own resources
+  - apiGroups:
+      - initialization.kcp.io
+    resources:
+      - inittargets
+      - inittemplates
+    verbs:
+      - get
+      - list
+      - watch
+
+  # allow to issue events on the cluster-scoped init-agent resources
   - apiGroups:
       - ""
     resources:
       - events
     verbs:
       - create
-      - patch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - syncagent.kcp.io
-    resources:
-      - publishedresources
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - syncagent.kcp.io
-    resources:
-      - publishedresources/status
-    verbs:
-      - create
-      - get
-      - update
       - patch
 
 ---

--- a/charts/init-agent/templates/configcluster/rbac.yaml
+++ b/charts/init-agent/templates/configcluster/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.target "configcluster" }}
+{{- if has "configcluster" .Values.targets }}
 {{- if .Values.leaderElection.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/init-agent/templates/host/deployment.yaml
+++ b/charts/init-agent/templates/host/deployment.yaml
@@ -1,0 +1,76 @@
+{{- if eq .Values.target "" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: '{{ template "name" . }}'
+  labels:
+    app.kubernetes.io/name: kcp-init-agent
+    app.kubernetes.io/instance: '{{ template "name" . }}'
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: '{{ template "name" . }}'
+spec:
+  replicas: {{ .Values.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kcp-init-agent
+      app.kubernetes.io/instance: '{{ template "name" . }}'
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kcp-init-agent
+        app.kubernetes.io/instance: '{{ template "name" . }}'
+        app.kubernetes.io/version: '{{ .Values.image.tag | default .Chart.AppVersion }}'
+    spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- include "imagePullSecrets" . | trim | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hostAliases.enabled }}
+      hostAliases:
+        {{- toYaml .Values.hostAliases.values | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: agent
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args:
+            - --config-workspace={{ .Values.configWorkspace }}
+            - --enable-leader-election={{ .Values.leaderElection.enabled }}
+            - --leader-election-namespace={{ .Values.leaderElection.namespace }}
+            - --kubeconfig=/etc/init-agent/kcp/kubeconfig
+            {{- with .Values.initTargetSelector }}
+            - "--init-target-selector={{ . }}"
+            {{- end }}
+            {{- range .Values.extraFlags }}
+            - {{ . | quote }}
+            {{- end }}
+          resources: {{ .Values.resources | toYaml | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: kcp-kubeconfig
+              mountPath: /etc/init-agent/kcp
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+{{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: '{{ template "name" . }}'
+      volumes:
+        - name: kcp-kubeconfig
+          secret:
+            secretName: '{{ required "Kubernetes Secret for the kcp kubeconfig must be configured." .Values.kcpKubeconfig }}'
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+
+{{- end }}

--- a/charts/init-agent/templates/host/deployment.yaml
+++ b/charts/init-agent/templates/host/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.target "" }}
+{{- if or (not .Values.targets) (has "host" .Values.targets) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/init-agent/templates/wstcluster/rbac.yaml
+++ b/charts/init-agent/templates/wstcluster/rbac.yaml
@@ -1,0 +1,32 @@
+{{- if eq .Values.target "wstcluster" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: 'kcp-init-agent:{{ template "name" . }}'
+rules:
+  - apiGroups:
+      - tenancy.kcp.io
+    resources:
+      - workspacetypes
+{{- with .Values.wstCluster.workspaceTypes }}
+    resourceNames:
+{{ . | toYaml | indent 6 }}
+{{- end}}
+    verbs:
+      - get
+      - list
+      - watch
+      - initialize
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: 'kcp-init-agent:{{ template "name" . }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'kcp-init-agent:{{ template "name" . }}'
+subjects:
+{{ list .Values.wstCluster.rbacSubject | toYaml | indent 2 }}
+{{- end }}

--- a/charts/init-agent/templates/wstcluster/rbac.yaml
+++ b/charts/init-agent/templates/wstcluster/rbac.yaml
@@ -4,6 +4,13 @@ kind: ClusterRole
 metadata:
   name: 'kcp-init-agent:{{ template "name" . }}'
 rules:
+  # provide access to this workspace
+  - verbs:
+      - access
+    nonResourceURLs:
+      - "/"
+
+  # allow to watch and initialize WorkspaceTypes
   - apiGroups:
       - tenancy.kcp.io
     resources:

--- a/charts/init-agent/templates/wstcluster/rbac.yaml
+++ b/charts/init-agent/templates/wstcluster/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.target "wstcluster" }}
+{{- if has "wstcluster" .Values.targets }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/init-agent/tests/combined.yaml
+++ b/charts/init-agent/tests/combined.yaml
@@ -1,4 +1,6 @@
 kcpKubeconfig: kcp-kubeconfig
 configWorkspace: root:init-agent
 targets:
+  - host
+  - configcluster
   - wstcluster

--- a/charts/init-agent/tests/configcluster.yaml
+++ b/charts/init-agent/tests/configcluster.yaml
@@ -1,0 +1,3 @@
+kcpKubeconfig: kcp-kubeconfig
+configWorkspace: root:init-agent
+target: configcluster

--- a/charts/init-agent/tests/configcluster.yaml
+++ b/charts/init-agent/tests/configcluster.yaml
@@ -1,3 +1,4 @@
 kcpKubeconfig: kcp-kubeconfig
 configWorkspace: root:init-agent
-target: configcluster
+targets:
+  - configcluster

--- a/charts/init-agent/tests/default.yaml
+++ b/charts/init-agent/tests/default.yaml
@@ -1,0 +1,2 @@
+kcpKubeconfig: kcp-kubeconfig
+configWorkspace: root:init-agent

--- a/charts/init-agent/tests/hostaliases.yaml
+++ b/charts/init-agent/tests/hostaliases.yaml
@@ -1,0 +1,9 @@
+kcpKubeconfig: kcp-kubeconfig
+configWorkspace: root:init-agent
+
+hostAliases:
+  enabled: true
+  values:
+    - ip: "1.2.3.5"
+      hostnames:
+      - "mysvc.example.dev.local"

--- a/charts/init-agent/tests/wstcluster.yaml
+++ b/charts/init-agent/tests/wstcluster.yaml
@@ -1,0 +1,3 @@
+kcpKubeconfig: kcp-kubeconfig
+configWorkspace: root:init-agent
+target: wstcluster

--- a/charts/init-agent/values.yaml
+++ b/charts/init-agent/values.yaml
@@ -3,7 +3,7 @@
 #
 # This Helm chart can be rendered in 3 different variations:
 #
-#   * By default, it will output a Deployment and necessary auxilirary resources
+#   * By default, it will output a Deployment and necessary auxiliary resources
 #     to *run* the init-agent in Kubernetes. Use this to "install" the agent.
 #     For this, configure Helm with a kubeconfig that points to the hosting
 #     Kubernetes cluster.
@@ -34,7 +34,7 @@ target: ""
 
 # Configuration exclusively for all the clusters (workspaces) in which the
 # init-agent is meant to read and initialize WorkspaceTypes in. The chart needs
-# to be installed into each of them to provision the necessar RBAC.
+# to be installed into each of them to provision the necessary RBAC.
 # Set target to "wstcluster" for this mode.
 wstCluster:
   # Required: RBAC Subject defines how the init-agent is authenticated in kcp.

--- a/charts/init-agent/values.yaml
+++ b/charts/init-agent/values.yaml
@@ -1,0 +1,123 @@
+#
+# Welcome to the kcp Init Agent!
+#
+# This Helm chart can be rendered in 3 different variations:
+#
+#   * By default, it will output a Deployment and necessary auxilirary resources
+#     to *run* the init-agent in Kubernetes. Use this to "install" the agent.
+#     For this, configure Helm with a kubeconfig that points to the hosting
+#     Kubernetes cluster.
+#   * By setting "target=configcluster", the chart will output the Init Agent
+#     CRDs, suitable to bootstrap a kcp workspace to create InitTargets and
+#     InitTemplates in kcp, plus the necessary RBAC for it.
+#     For this, Helm needs to be configured with a kubeconfig that points to
+#     the desired config workspace.
+#   * By setting "target=wstcluster", the chart will only output the necessary
+#     RBAC to allow the agent to access WorkspaceTypes and to initialize them
+#     in a single workspace. This variation has to be installed in each workspace
+#     for which InitTargets are configured in the configWorkspace.
+#     For this, Helm needs to be configured with a kubeconfig that points to
+#     the desired workspace.
+#
+# All three modes must be installed for the init-agent to function correctly.
+#
+
+# Leader election happens inside the configWorkspace and must be enabled if
+# replicas is larger than 1.
+leaderElection:
+  enabled: true
+  namespace: kcp-init-agent
+
+# Required: set to "" (default, hosting cluster), "configcluster" or "wstcluster"
+# (see comment above) to output the correct manifests for each Kubernetes endpoint.
+target: ""
+
+# Configuration exclusively for all the clusters (workspaces) in which the
+# init-agent is meant to read and initialize WorkspaceTypes in. The chart needs
+# to be installed into each of them to provision the necessar RBAC.
+# Set target to "wstcluster" for this mode.
+wstCluster:
+  # Required: RBAC Subject defines how the init-agent is authenticated in kcp.
+  # This field entirely depends on the kubeconfig (further down) you provide
+  # to the init-agent. In many cases, you will want to use client certificates
+  # and then configure a user subject here, like demonstrated below.
+  rbacSubject:
+    kind: User
+    name: my-init-agent
+
+  # Optional: Tighten permissions for the init-agent by listing the names of the
+  # workspace types that it is allowed to initialize. If not specified, the
+  # generated RBAC will allow the init-agent to initialize all workspaces in
+  # the cluster where the chart is installed into.
+  workspaceTypes: []
+
+# Configuration for the config workspace, where the InitTargets and related objects
+# live. This is the "home" workspace for the init-agent, where also leader election
+# happens.
+configCluster:
+  # Required: RBAC Subject defines how the init-agent is authenticated in kcp.
+  # This field entirely depends on the kubeconfig (further down) you provide
+  # to the init-agent. In many cases, you will want to use client certificates
+  # and then configure a user subject here, like demonstrated below.
+  rbacSubject:
+    kind: User
+    name: my-init-agent
+
+# Required: The kcp workspace (or cluster name) where the init-agent CRDs, InitTargets
+# and InitTemplates reside.
+configWorkspace: ""
+
+# Required: Name of the Kubernetes Secret that contains a "kubeconfig" key, with the
+# kubeconfig provided by kcp to access it. This kubeconfig should point to base address
+# of kcp.
+kcpKubeconfig: ""
+
+# Optional: If two or more Init Agents are installed to process the same config workspace,
+# each one must have a Kubernetes label selector to scope down which InitTargets they
+# process, as no two agents must process the same.
+# If just one Init Agents is installed in the cluster, this can be left blank.
+initTargetSelector: ""
+
+replicas: 2
+
+# The container image to use for the Sync Agent.
+image:
+  repository: "ghcr.io/kcp-dev/init-agent"
+  # set this to override the image tag used (determined by chart appVersion by default).
+  tag: ""
+
+## Reference to one or more secrets to be used when pulling images
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+##
+imagePullSecrets: []
+# - name: "image-pull-secret"
+# or
+# - "image-pull-secret"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 64Mi
+  limits:
+    cpu: 1
+    memory: 512Mi
+
+# Optional: Pass additional flags to the kcp-api-syncagent process started by the container.
+extraFlags: []
+
+# Optional: Configure additional volumes to be added to the syncagent Pod.
+extraVolumes: []
+#  - name: extra-secret
+#    secret:
+#      secretName: extra-secret
+
+# Optional: Configure additional volume mounts to be added to the agent container.
+extraVolumeMounts: []
+#  - name: extra-secret
+#    mountPath: /etc/test
+
+hostAliases:
+  enabled: false
+  values:
+    - ip: ""
+      hostnames: []

--- a/charts/init-agent/values.yaml
+++ b/charts/init-agent/values.yaml
@@ -1,23 +1,28 @@
 #
 # Welcome to the kcp Init Agent!
 #
-# This Helm chart can be rendered in 3 different variations:
+# This Helm chart can be rendered in 3 different variations, controlled by the
+# "targets" list:
 #
-#   * By default, it will output a Deployment and necessary auxiliary resources
-#     to *run* the init-agent in Kubernetes. Use this to "install" the agent.
-#     For this, configure Helm with a kubeconfig that points to the hosting
-#     Kubernetes cluster.
-#   * By setting "target=configcluster", the chart will output the Init Agent
-#     CRDs, suitable to bootstrap a kcp workspace to create InitTargets and
-#     InitTemplates in kcp, plus the necessary RBAC for it.
+#   * By default (targets is empty) or by including "host" in targets, it will
+#     output a Deployment and necessary auxiliary resources to *run* the
+#     init-agent in Kubernetes. Use this to "install" the agent. For this,
+#     configure Helm with a kubeconfig that points to the hosting Kubernetes
+#     cluster.
+#   * By including "configcluster" in targets, the chart will output the Init
+#     Agent CRDs, suitable to bootstrap a kcp workspace to create InitTargets
+#     and InitTemplates in kcp, plus the necessary RBAC for it.
 #     For this, Helm needs to be configured with a kubeconfig that points to
 #     the desired config workspace.
-#   * By setting "target=wstcluster", the chart will only output the necessary
-#     RBAC to allow the agent to access WorkspaceTypes and to initialize them
-#     in a single workspace. This variation has to be installed in each workspace
-#     for which InitTargets are configured in the configWorkspace.
-#     For this, Helm needs to be configured with a kubeconfig that points to
-#     the desired workspace.
+#   * By including "wstcluster" in targets, the chart will only output the
+#     necessary RBAC to allow the agent to access WorkspaceTypes and to
+#     initialize them in a single workspace. This variation has to be installed
+#     in each workspace for which InitTargets are configured in the
+#     configWorkspace. For this, Helm needs to be configured with a kubeconfig
+#     that points to the desired workspace.
+#
+# Multiple targets can be combined (e.g. ["configcluster", "wstcluster"]) to
+# output manifests for several targets at once.
 #
 # All three modes must be installed for the init-agent to function correctly.
 #
@@ -28,9 +33,10 @@ leaderElection:
   enabled: true
   namespace: kcp-init-agent
 
-# Required: set to "" (default, hosting cluster), "configcluster" or "wstcluster"
-# (see comment above) to output the correct manifests for each Kubernetes endpoint.
-target: ""
+# Set to one or more of "host", "configcluster" and "wstcluster" (see comment
+# above) to output the correct manifests for each Kubernetes endpoint. Leave
+# empty (default) to output the hosting cluster manifests (Deployment etc.).
+targets: []
 
 # Configuration exclusively for all the clusters (workspaces) in which the
 # init-agent is meant to read and initialize WorkspaceTypes in. The chart needs

--- a/charts/init-agent/values.yaml
+++ b/charts/init-agent/values.yaml
@@ -63,6 +63,9 @@ configCluster:
     kind: User
     name: my-init-agent
 
+  crds:
+    create: true
+
 # Required: The kcp workspace (or cluster name) where the init-agent CRDs, InitTargets
 # and InitTemplates reside.
 configWorkspace: ""


### PR DESCRIPTION
This PR creates a new Helm chart to install [init-agent](https://github.com/kcp-dev/init-agent).

This chart is special in a sense that it can output 3 different sets of manifests, based on the `target` value. This is so that you have just one chart to

* setup the init-agent itself (i.e. a Deployment)
* setup RBAC in a kcp workspace where InitTargets are managed
* setup RBAC in any other kcp workspace where there are WorkspaceTypes that need initialization

I've tested this chart in a kind-based cluster using the kcp-operator to provision stuff for me. There's a documentation PR @ https://github.com/kcp-dev/init-agent/pull/6 that outlines the process.