### PR TITLE
update api-syncagent to 0.5, drop support for APIExportRef

### DIFF
--- a/charts/api-syncagent/Chart.yaml
+++ b/charts/api-syncagent/Chart.yaml
@@ -3,8 +3,8 @@ name: api-syncagent
 description: A Kubernetes agent to synchronize APIs and their objects between Kubernetes clusters and kcp.
 
 # version information
-version: 0.4.5
-appVersion: "v0.4.2"
+version: 0.5.0
+appVersion: "v0.5.0"
 
 # optional metadata
 type: application

--- a/charts/api-syncagent/templates/crd-publishedresource.yaml
+++ b/charts/api-syncagent/templates/crd-publishedresource.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: publishedresources.syncagent.kcp.io
 spec:
   group: syncagent.kcp.io
@@ -156,6 +156,16 @@ spec:
                     spec:
                       items:
                         properties:
+                          cel:
+                            properties:
+                              expression:
+                                type: string
+                              path:
+                                type: string
+                            required:
+                              - expression
+                              - path
+                            type: object
                           delete:
                             properties:
                               path:
@@ -192,6 +202,16 @@ spec:
                     status:
                       items:
                         properties:
+                          cel:
+                            properties:
+                              expression:
+                                type: string
+                              path:
+                                type: string
+                            required:
+                              - expression
+                              - path
+                            type: object
                           delete:
                             properties:
                               path:
@@ -348,8 +368,23 @@ spec:
                       type: object
                   type: object
                 related:
+                  description: |-
+                    Related configures additional resources that semantically belong to the synced
+                    resource, like a Secret containing generated credentials. Related objects are
+                    synced along the main resource.
                   items:
+                    description: |-
+                      RelatedResourceSpec describes a single related resource, which might point to
+                      any number of actual Kubernetes objects.
+
+                      (in the following rule, group is optional becaue core/v1 is represented by group="")
+                      group is included here because when an identityHash is used, core/v1 cannot possible be targetted
                     properties:
+                      group:
+                        description: |-
+                          Group is the API group of the related resource. This should be left blank for resources
+                          in the core API group.
+                        type: string
                       identifier:
                         description: |-
                           Identifier is a unique name for this related resource. The name must be unique within one
@@ -357,8 +392,20 @@ spec:
                           related resource. Common names are "connection-details" or "credentials".
                           The identifier must be an alphanumeric string.
                         type: string
+                      identityHash:
+                        description: |-
+                          IdentityHash is the identity hash of a kcp APIExport, in case the given Kind is
+                          provided by an APIExport and not Kube-native.
+                        type: string
                       kind:
-                        description: ConfigMap or Secret
+                        description: |-
+                          Kind is the object kind of the related resource (for example "Secret").
+
+                          Deprecated: Use "Resource" instead. This field is limited to "ConfigMap" and "Secret" and will
+                          be removed in the future. Kind and Resource cannot be specified at the same time.
+                        enum:
+                          - ConfigMap
+                          - Secret
                         type: string
                       mutation:
                         description: |-
@@ -368,6 +415,16 @@ spec:
                           spec:
                             items:
                               properties:
+                                cel:
+                                  properties:
+                                    expression:
+                                      type: string
+                                    path:
+                                      type: string
+                                  required:
+                                    - expression
+                                    - path
+                                  type: object
                                 delete:
                                   properties:
                                     path:
@@ -404,6 +461,16 @@ spec:
                           status:
                             items:
                               properties:
+                                cel:
+                                  properties:
+                                    expression:
+                                      type: string
+                                    path:
+                                      type: string
+                                  required:
+                                    - expression
+                                    - path
+                                  type: object
                                 delete:
                                   properties:
                                     path:
@@ -685,12 +752,45 @@ spec:
                           - service
                           - kcp
                         type: string
+                      projection:
+                        description: |-
+                          Projection is used to change the GVK of a related resource on the opposite side of
+                          its origin.
+                          All fields in the projection are optional. If a field is set, it will overwrite
+                          that field in the GVK.
+                        properties:
+                          group:
+                            description: The API group, for example "myservice.example.com". Leave empty to not modify the API group.
+                            type: string
+                          resource:
+                            description: The resource name, for example "databases". Leave empty to not modify the resource.
+                            type: string
+                          version:
+                            description: The API version, for example "v1beta1". Leave empty to not modify the version.
+                            type: string
+                        type: object
+                      resource:
+                        description: Resource is the name of the related resource (for example "secrets").
+                        type: string
+                      version:
+                        description: |-
+                          Version is the API version of the related resource. This can be left blank to automatically
+                          use the preferred version.
+                        type: string
                     required:
                       - identifier
-                      - kind
                       - object
                       - origin
                     type: object
+                    x-kubernetes-validations:
+                      - message: must specify either kind (deprecated) or group, version, resource
+                        rule: has(self.kind) != (has(self.version) || has(self.resource))
+                      - message: resource and version must be configured together or not at all
+                        rule: has(self.resource) == has(self.version)
+                      - message: configuring a group also requires a version and resource
+                        rule: '!has(self.group) || (has(self.resource) && has(self.version))'
+                      - message: identity hashes can only be used with GVRs
+                        rule: '!has(self.identityHash) || (has(self.group) && has(self.version) && has(self.resource))'
                   type: array
                 resource:
                   description: |-
@@ -721,6 +821,22 @@ spec:
                   required:
                     - apiGroup
                     - kind
+                  type: object
+                synchronization:
+                  description: Synchronization allows to configure how the syncagent processes this resource.
+                  properties:
+                    enabled:
+                      description: |-
+                        Enabled can be used to toggle the synchronization as a whole. When set to
+                        false, the syncagent will only copy the CRD and include it in the APIExport,
+                        but not will attempt to synchronize objects of this resource from the kcp
+                        workspaces to the provider.
+                        Synchronization must be disabled for resources that are used as related
+                        resources for other PublishedResources. Otherwise the syncagent would
+                        potentially loop and never finish processing an object.
+                      type: boolean
+                  required:
+                    - enabled
                   type: object
               required:
                 - resource

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -37,13 +37,7 @@ spec:
           args:
             - --namespace=$(POD_NAMESPACE)
             - --enable-leader-election={{ .Values.enableLeaderElection }}
-            {{- with .Values.apiExportEndpointSliceName }}
-            - --apiexportendpointslice-ref={{ . }}
-            {{- else with .Values.apiExportName }}
-            - --apiexport-ref={{ . }}
-            {{- else }}
-            {{- required "Either an APIExportEndpointSliceRef or APIExportRef must be configured." "" }}
-            {{- end }}
+            - --apiexportendpointslice-ref={{ required "APIExportEndpointSlice name must be configured" .Values.apiExportEndpointSliceName }}
             - --agent-name=$(AGENT_NAME)
             - --kcp-kubeconfig=/etc/api-syncagent/kcp/kubeconfig
             {{- with .Values.kubeconfig }}

--- a/charts/api-syncagent/tests/default.yaml
+++ b/charts/api-syncagent/tests/default.yaml
@@ -1,3 +1,3 @@
 externalHostname: ci.kcp.io
-apiExportName: my-api
+apiExportEndpointSliceName: my-api
 kcpKubeconfig: kcp-kubeconfig

--- a/charts/api-syncagent/tests/hostaliases.yaml
+++ b/charts/api-syncagent/tests/hostaliases.yaml
@@ -1,5 +1,5 @@
 externalHostname: ci.kcp.io
-apiExportName: my-api
+apiExportEndpointSliceName: my-api
 kcpKubeconfig: kcp-kubeconfig
 
 hostAliases:

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -8,15 +8,8 @@ global:
   # - "image-pull-secret"
 
 # Required: You need to configure a reference to an APIExportEndpointSlice so the
-# agent knows which API to serve and where to connect to. For kcp 0.27, you can
-# also instead configure an APIExport, but this is not recommended and could cause
-# issues when upgrading kcp.
+# agent knows which API to serve and where to connect to.
 apiExportEndpointSliceName: ""
-
-# Alternatively: the name of the APIExport in kcp that this Sync Agent is supposed
-# to serve. Configuring an APIExportEndpointSlice instead is recommended and
-# futureproof.
-# apiExportName: ""
 
 # This Agent's public name, purely for informational purposes. If not set, defaults
 # to the Helm release name.


### PR DESCRIPTION
https://github.com/kcp-dev/api-syncagent/releases/tag/v0.5.0 was just released, time to update the chart.

The --apiexport-ref flag was removed, so from now on users will have to use an APIExportEndpointSlice.