### PR TITLE
Fix disabled-controllers join separator in Helm template

### DIFF
--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - "--published-resource-selector={{ . }}"
             {{- end }}
             {{- with .Values.disabledControllers }}
-            - "--disabled-controllers={{ . | join ',' }}"
+            - "--disabled-controllers={{ join "," . }}"
             {{- end }}
             {{- range .Values.extraFlags }}
             - {{ . | quote }}


### PR DESCRIPTION
Helm template rendering fails when disabledControllers is set:

Error:
template: api-syncagent/templates/deployment.yaml:56:50: at <','>: expected string; found ','

Root cause:
Single quotes in Go templates produce a rune (int32), but join expects a string separator.

This replaces join ',' with join ",".
