### PR TITLE
Init agent 0.1.1

### DIFF
--- a/charts/init-agent/Chart.yaml
+++ b/charts/init-agent/Chart.yaml
@@ -3,8 +3,8 @@ name: init-agent
 description: A Kubernetes agent to initialize newly created workspaces with Kubernetes objects.
 
 # version information
-version: 0.1.0
-appVersion: "v0.1.0"
+version: 0.1.1
+appVersion: "v0.1.1"
 
 # optional metadata
 type: application

--- a/charts/init-agent/templates/configcluster/leaderelection.yaml
+++ b/charts/init-agent/templates/configcluster/leaderelection.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.leaderElection.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.leaderElection.namespace }}
+{{- end }}

--- a/charts/init-agent/tests/configcluster.yaml
+++ b/charts/init-agent/tests/configcluster.yaml
@@ -2,3 +2,5 @@ kcpKubeconfig: kcp-kubeconfig
 configWorkspace: root:init-agent
 targets:
   - configcluster
+leaderElection:
+  create: true

--- a/charts/init-agent/values.yaml
+++ b/charts/init-agent/values.yaml
@@ -33,6 +33,11 @@ leaderElection:
   enabled: true
   namespace: kcp-init-agent
 
+  # If the namespace above is different than the namespace where the Helm chart
+  # is installed into, set this to true to create the leader election namespace
+  # as well.
+  create: false
+
 # Set to one or more of "host", "configcluster" and "wstcluster" (see comment
 # above) to output the correct manifests for each Kubernetes endpoint. Leave
 # empty (default) to output the hosting cluster manifests (Deployment etc.).


### PR DESCRIPTION
This bumps the init-agent to 0.1.1 (the first release to actually have leader-election flags available) and then adds some templating to create the LE namespace, if desired.