### PR TITLE
bump init-agent to 0.2

### DIFF
--- a/charts/init-agent/Chart.yaml
+++ b/charts/init-agent/Chart.yaml
@@ -3,8 +3,8 @@ name: init-agent
 description: A Kubernetes agent to initialize newly created workspaces with Kubernetes objects.
 
 # version information
-version: 0.1.1
-appVersion: "v0.1.1"
+version: 0.2.0
+appVersion: "v0.2.0"
 
 # optional metadata
 type: application


### PR DESCRIPTION
This ships the latest release of the init-agent: https://github.com/kcp-dev/init-agent/releases/tag/v0.2.0

CRDs have not changed since 0.1.x.