### PR TITLE
Fix FORMERR errors in CoreDNS due to missing entries in etcd certificates DNS Names 

### DIFF
--- a/charts/certificates/templates/etcd-certificates.yaml
+++ b/charts/certificates/templates/etcd-certificates.yaml
@@ -22,12 +22,24 @@ spec:
     - client auth  # required because etcd uses this cert for calls to itself
   dnsNames:
     - {{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
     - {{ include "etcd.fullname" . }}-0
-    - {{ include "etcd.fullname" . }}-1
-    - {{ include "etcd.fullname" . }}-2
     - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "etcd.fullname" . }}-1
     - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "etcd.fullname" . }}-2
     - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
   ipAddresses:
     - 0.0.0.0
   issuerRef:
@@ -66,11 +78,20 @@ spec:
     - client auth
   dnsNames:
     - {{ include "etcd.fullname" . }}-0
-    - {{ include "etcd.fullname" . }}-1
-    - {{ include "etcd.fullname" . }}-2
     - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "etcd.fullname" . }}-1
     - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "etcd.fullname" . }}-2
     - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
   ipAddresses:
     - 0.0.0.0
   issuerRef:

--- a/charts/kcp/templates/etcd-certificates.yaml
+++ b/charts/kcp/templates/etcd-certificates.yaml
@@ -21,12 +21,24 @@ spec:
     - client auth  # required because etcd uses this cert for calls to itself
   dnsNames:
     - {{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
     - {{ include "etcd.fullname" . }}-0
-    - {{ include "etcd.fullname" . }}-1
-    - {{ include "etcd.fullname" . }}-2
     - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "etcd.fullname" . }}-1
     - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "etcd.fullname" . }}-2
     - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
   ipAddresses:
     - 0.0.0.0
     {{- with .Values.certificates.ipAddresses }}
@@ -60,11 +72,20 @@ spec:
     - client auth
   dnsNames:
     - {{ include "etcd.fullname" . }}-0
-    - {{ include "etcd.fullname" . }}-1
-    - {{ include "etcd.fullname" . }}-2
     - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-0.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "etcd.fullname" . }}-1
     - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-1.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "etcd.fullname" . }}-2
     - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "etcd.fullname" . }}-2.{{ include "etcd.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
   ipAddresses:
     - 0.0.0.0
     {{- with .Values.certificates.ipAddresses }}


### PR DESCRIPTION
This PR corrects an issue with the DNSNames entries in kcp etcd certificates created by this chart. As per etcd [documentation](https://etcd.io/docs/v3.6/op-guide/kubernetes/):

> This manifest creates Certificate objects for the client and server certs, referencing the ClusterIssuer “selfsigned”. The dnsNames should be an exhaustive list of valid hostnames for the certificates that cert-manager creates.

The current list is not exhaustive and it's causing dns resolution issues that, in WSL Docker running on Windows 11, is causing a substantial memory leak in the Windows DNS Client:

<img width="733" height="93" alt="image" src="https://github.com/user-attachments/assets/12c20f49-5570-42c9-aa96-41e4f4b9ebb9" />

This is caused by a flood of failed DNS queries in CoreDNS that tries to resolve the missing DNS Names in the upstream resolver:

```
[INFO] 10.10.0.90:41187 - 51853 "AAAA IN kcp-etcd-0. udp 57 false 1232" FORMERR qr,rd 46 0.097144528s
[INFO] 10.10.0.77:44265 - 53506 "A IN kcp-etcd-1. udp 57 false 1232" FORMERR qr,rd 46 0.094501241s
[INFO] 10.10.0.90:43964 - 11428 "A IN kcp-etcd-1. udp 57 false 1232" FORMERR qr,rd 46 0.094797905s
[INFO] 10.10.0.90:36946 - 13972 "A IN kcp-etcd-1. udp 57 false 1232" FORMERR qr,rd 46 0.0949005s
[INFO] 10.10.0.90:34906 - 26588 "AAAA IN kcp-etcd-1. udp 57 false 1232" FORMERR qr,rd 46 0.095403817s
```

With the new list, CoreDNS log is clean and the resolution works as intended.