### PR TITLE
lint: add helm lint to chart validation script

### DIFF
--- a/hack/ci/render-helm-charts.sh
+++ b/hack/ci/render-helm-charts.sh
@@ -35,6 +35,12 @@ for dir in ./charts/*/; do
   dir="${dir%*/}"
   chart="${dir##*/}"
 
+  heading "$chart: helm lint"
+  helm lint "$dir"
+
+  echo
+  echo
+
   for testfile in "$dir"/tests/*.yaml; do
     heading "$chart: $(basename $testfile)"
 


### PR DESCRIPTION
This adds a `helm lint` step to the existing `render-helm-charts.sh` script.

Each Helm chart under `./charts/` is now linted before templating, so issues are caught early.

Note: No charts currently fail linting, but warnings may appear if required values are missing. For example:

```bash
level=WARN msg="missing required values" message="APIExportEndpointSlice name must be configured"
level=WARN msg="missing required values" message="Kubernetes Secret for the kcp kubeconfig must be configured."
```

Closes #198 