### PR TITLE
api-syncagent: add nodeSelector, affinity, and tolerations

### DIFF
--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -102,3 +102,16 @@ spec:
 {{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}
 
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -86,3 +86,15 @@ hostAliases:
   values:
     - ip: ""
       hostnames: []
+
+# This configures the node selector for scheduling api-syncagent to specific nodes.
+# For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+nodeSelector: {}
+
+# This configures tolerations to allow api-syncagent to be scheduled to Nodes with taints.
+# For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/.
+tolerations: []
+
+# This configures advanced scheduling affinity settings to fine-tune where api-syncagent runs.
+# For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.
+affinity: {}


### PR DESCRIPTION
This adds `nodeSelector`, `affinity`, and `tolerations` support to the api-syncagent chart.

The implementation follows the same pattern used in the kcp-operator chart for consistency.

Closes #201 