### PR TITLE
init-agent: add nodeSelector, affinity, and tolerations

### DIFF
--- a/charts/init-agent/templates/host/deployment.yaml
+++ b/charts/init-agent/templates/host/deployment.yaml
@@ -73,4 +73,17 @@ spec:
 {{ toYaml .Values.extraVolumes | indent 8 }}
 {{- end }}
 
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
 {{- end }}

--- a/charts/init-agent/values.yaml
+++ b/charts/init-agent/values.yaml
@@ -135,3 +135,15 @@ hostAliases:
   values:
     - ip: ""
       hostnames: []
+
+# This configures the node selector for scheduling init-agent to specific nodes.
+# For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+nodeSelector: {}
+
+# This configures tolerations to allow init-agent to be scheduled to Nodes with taints.
+# For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/.
+tolerations: []
+
+# This configures advanced scheduling affinity settings to fine-tune where init-agent runs.
+# For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.
+affinity: {}


### PR DESCRIPTION
This adds nodeSelector, affinity, and tolerations support to the init-agent chart.

The implementation follows the same pattern used in the kcp-operator chart for consistency.

Closes #202 