### PR TITLE
kcp: add nodeSelector

### DIFF
--- a/charts/kcp/templates/etcd-statefulset.yaml
+++ b/charts/kcp/templates/etcd-statefulset.yaml
@@ -49,6 +49,10 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app.kubernetes.io/component: "etcd"
     spec:
+      {{- with .Values.etcd.nodeSelector}}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.etcd.affinity}}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -64,6 +64,10 @@ spec:
       hostAliases:
         {{- toYaml .Values.kcpFrontProxy.hostAliases.values | nindent 8 }}
       {{- end }}
+      {{- with .Values.kcpFrontProxy.nodeSelector}}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.kcpFrontProxy.affinity}}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -98,6 +98,10 @@ spec:
       hostAliases:
         {{- toYaml .Values.kcp.hostAliases.values | nindent 8 }}
       {{- end }}
+      {{- with .Values.kcp.nodeSelector}}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.kcp.affinity}}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -41,6 +41,10 @@ etcd:
     enabled: false
     maxUnavailable: 1
 
+  # This configures the node selector for scheduling kcp etcd pods to specific nodes.
+  # For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+  nodeSelector: {}
+
   # When configured, this will add tolerations to the pods.
   tolerations: []
   #  - key: "kcp"
@@ -150,6 +154,10 @@ kcp:
   podDisruptionBudget:
     enabled: false
     minAvailable: 1
+
+  # This configures the node selector for scheduling kcp server pods to specific nodes.
+  # For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+  nodeSelector: {}
 
   # When configured, this will add tolerations to the pods.
   tolerations: []
@@ -310,6 +318,10 @@ kcpFrontProxy:
   extraVolumeMounts: []
   # - name: example-vw-serving-cert
   #   mountPath: /etc/example-vw-serving-cert
+
+  # This configures the node selector for scheduling kcp-front-proxy pods to specific nodes.
+  # For more information see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+  nodeSelector: {}
 
   # When configured, this will add tolerations to the pods.
   tolerations: []


### PR DESCRIPTION
This adds nodeSelector to the kcp chart.

The implementation follows the same pattern used in the kcp-operator chart for consistency.

Closes #203 