### PR TITLE
api-syncagent: optional service account creation

### DIFF
--- a/charts/api-syncagent/templates/_helpers.tpl
+++ b/charts/api-syncagent/templates/_helpers.tpl
@@ -10,3 +10,59 @@
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "api-syncagent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "api-syncagent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "api-syncagent.labels" -}}
+helm.sh/chart: {{ include "api-syncagent.chart" . }}
+{{ include "api-syncagent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "api-syncagent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "api-syncagent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "api-syncagent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -1,12 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: '{{ template "name" . }}'
-  labels:
-    app.kubernetes.io/name: kcp-api-syncagent
-    app.kubernetes.io/instance: '{{ template "agentname" . }}'
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -86,7 +77,7 @@ spec:
       securityContext:
         {{- toYaml .Values.securityContext.pod | nindent 8 }}
       {{- end }}
-      serviceAccountName: '{{ template "name" . }}'
+      serviceAccountName: {{ include "api-syncagent.serviceAccountName" . }}
       volumes:
         - name: kcp-kubeconfig
           secret:
@@ -112,4 +103,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-

--- a/charts/api-syncagent/templates/rbac.yaml
+++ b/charts/api-syncagent/templates/rbac.yaml
@@ -27,14 +27,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: '{{ template "name" . }}:leaderelection'
+  name: {{ include "api-syncagent.fullname" . }}:{{ include "api-syncagent.serviceAccountName" . }}:leaderelection
+  labels:
+    {{- include "api-syncagent.labels" . | nindent 4 }}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: '{{ template "name" . }}:leaderelection'
+  name: {{ include "api-syncagent.fullname" . }}:leaderelection
 subjects:
-  - kind: ServiceAccount
-    name: '{{ template "name" . }}'
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "api-syncagent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 
 ---
 # A dedicated role and binding just to allow the agent to publish events on PublishedResources,
@@ -52,9 +58,10 @@ roleRef:
   kind: Role
   name: '{{ template "name" . }}:{{ .Release.Namespace }}:events'
 subjects:
-  - kind: ServiceAccount
-    name: '{{ template "name" . }}'
-    namespace: '{{ .Release.Namespace }}'
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "api-syncagent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -133,6 +140,7 @@ roleRef:
   kind: ClusterRole
   name: '{{ template "name" . }}:{{ .Release.Namespace }}'
 subjects:
-  - kind: ServiceAccount
-    name: '{{ template "name" . }}'
-    namespace: '{{ .Release.Namespace }}'
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "api-syncagent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/api-syncagent/templates/serviceaccount.yaml
+++ b/charts/api-syncagent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "api-syncagent.serviceAccountName" . }}
+  labels:
+    {{- include "api-syncagent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -6,6 +6,9 @@ global:
   # - name: "image-pull-secret"
   # or
   # - "image-pull-secret"
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
 
 # Required: You need to configure a reference to an APIExportEndpointSlice so the
 # agent knows which API to serve and where to connect to.
@@ -66,6 +69,21 @@ resources:
 crds:
   # Whether to install the PublishedResource CRD.
   enabled: true
+
+# This section builds out the service account. More information can be found here: https://github.com/kcp-dev/helm-charts/issues/206
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+# This is for setting Kubernetes Annotations to the api-syncagent Deployment.
+annotations: {}
 
 # Optional: Pass additional flags to the kcp-api-syncagent process started by the container.
 extraFlags: []


### PR DESCRIPTION
This makes the service account creation optional to the `api-syncagent` chart.

The implementation follows the same pattern used in the `kcp-operator` chart for consistency.

Closes #204 