### PR TITLE
fix: update rbac for kcp-operator

### DIFF
--- a/charts/kcp-operator/templates/rbac.yaml
+++ b/charts/kcp-operator/templates/rbac.yaml
@@ -47,9 +47,9 @@ rules:
 - apiGroups:
   - operator.kcp.io
   resources:
+  - bundles
   - cacheservers
   - frontproxies
-  - shards
   verbs:
   - create
   - delete
@@ -61,6 +61,7 @@ rules:
 - apiGroups:
   - operator.kcp.io
   resources:
+  - bundles/finalizers
   - cacheservers/finalizers
   - frontproxies/finalizers
   - kubeconfigs/finalizers
@@ -71,11 +72,13 @@ rules:
 - apiGroups:
   - operator.kcp.io
   resources:
+  - bundles/status
   - cacheservers/status
   - frontproxies/status
   - kubeconfigs/status
   - rootshards/status
   - shards/status
+  - virtualworkspaces/status
   verbs:
   - get
   - patch
@@ -85,6 +88,8 @@ rules:
   resources:
   - kubeconfigs
   - rootshards
+  - shards
+  - virtualworkspaces
   verbs:
   - get
   - list


### PR DESCRIPTION
resolves https://github.com/kcp-dev/kcp-operator/issues/210

I regenerated the corresponding ClusterRole in the kcp-operator repository using `controller-gen` and copied the file to this repository.

Hope that's correct.

I successfully installed the kcp-operator helm chart in kind cluster without the rbac errors described in the linked issue