### PR TITLE
Add namespace to kcp-operator manifests

### DIFF
--- a/charts/kcp-operator/Chart.yaml
+++ b/charts/kcp-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kcp-operator
 description: A Helm chart for kcp-operator, a Kubernetes operator to deploy and manage kcp instances.
 # version information
-version: 0.7.0
-appVersion: "v0.7.0"
+version: 0.7.1
+appVersion: "v0.7.1"
 # optional metadata
 type: application
 home: https://kcp.io

--- a/charts/kcp-operator/Chart.yaml
+++ b/charts/kcp-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kcp-operator
 description: A Helm chart for kcp-operator, a Kubernetes operator to deploy and manage kcp instances.
 # version information
-version: 0.7.1
-appVersion: "v0.7.1"
+version: 0.7.3
+appVersion: "v0.7.3"
 # optional metadata
 type: application
 home: https://kcp.io

--- a/charts/kcp-operator/Chart.yaml
+++ b/charts/kcp-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: kcp-operator
 description: A Helm chart for kcp-operator, a Kubernetes operator to deploy and manage kcp instances.
 # version information
 version: 0.7.3
-appVersion: "v0.7.3"
+appVersion: "v0.7.2"
 # optional metadata
 type: application
 home: https://kcp.io

--- a/charts/kcp-operator/templates/deployment.yaml
+++ b/charts/kcp-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kcp-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kcp-operator.labels" . | nindent 4 }}
   annotations:

--- a/charts/kcp-operator/templates/rbac.yaml
+++ b/charts/kcp-operator/templates/rbac.yaml
@@ -122,6 +122,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kcp-operator.fullname" . }}:leaderelection
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kcp-operator.labels" . | nindent 4 }}
   annotations: 
@@ -150,6 +151,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kcp-operator.fullname" . }}:{{ include "kcp-operator.serviceAccountName" . }}:leaderelection
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kcp-operator.labels" . | nindent 4 }}
   annotations: 

--- a/charts/kcp-operator/templates/service.yaml
+++ b/charts/kcp-operator/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kcp-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kcp-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/kcp-operator/templates/serviceaccount.yaml
+++ b/charts/kcp-operator/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kcp-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kcp-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Fixes #225 

Adds a namespace to the manifests so the chart can also be prerendered and deployed to kubernetes. 