### PR TITLE
added identities for tenancy.kcp.io and topology.kcp.io

### DIFF
--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -198,6 +198,9 @@ spec:
             {{- if .Values.kcp.leaderElection.enabled }}
             - --enable-leader-election
             {{- end }}
+            {{- if .Values.development.rootIdentities.enabled }}
+            - --root-identities-file=/etc/kcp/identities/{{ .Values.development.rootIdentities.fileName }}
+            {{- end }}
             {{- range .Values.kcp.extraFlags }}
             - {{ . }}
             {{- end }}
@@ -288,6 +291,10 @@ spec:
               mountPath: /etc/kcp/external-logical-cluster-admin/kubeconfig
             - name: external-logical-cluster-admin-kubeconfig-cert
               mountPath: /etc/kcp/external-logical-cluster-admin/kubeconfig-client-cert
+            {{- if .Values.development.rootIdentities.enabled }}
+            - name: kcp-root-identities
+              mountPath: /etc/kcp/identities
+            {{- end }}
 {{- with .Values.kcp.extraVolumeMounts }}
 {{ . | toYaml | indent 12 }}
 {{- end }}
@@ -362,6 +369,11 @@ spec:
         - name: external-logical-cluster-admin-kubeconfig-cert
           secret:
             secretName: {{ include "kcp.fullname" . }}-external-admin-kubeconfig-cert
+        {{- if .Values.development.rootIdentities.enabled }}
+        - name: kcp-root-identities
+          secret:
+            secretName: {{ .Values.development.rootIdentities.existingSecret | default (printf "%s-root-identities" (include "kcp.fullname" .)) }}
+        {{- end }}
 {{- with .Values.kcp.extraVolumes }}
 {{ . | toYaml | indent 8 }}
 {{- end }}
@@ -385,3 +397,18 @@ stringData:
   {{ .Values.kcp.tokenAuth.fileName }}: |
     {{- .Values.kcp.tokenAuth.config | nindent 4 }}
 {{- end}}
+
+{{- if and .Values.development.rootIdentities.enabled (not .Values.development.rootIdentities.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kcp.fullname" . }}-root-identities
+stringData:
+  {{ .Values.development.rootIdentities.fileName }}: |
+    identities:
+    {{- range .Values.development.rootIdentities.identities }}
+      - export: {{ .export }}
+        identity: {{ .identity | quote }}
+    {{- end }}
+{{- end }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -195,6 +195,22 @@ kcp:
   #   mountPath: "/etc/foo"
   #   readOnly: true
 
+development:
+  # rootIdentities pins APIExport identity hashes in the root workspace so they are
+  # deterministic across installs/shards (identityHash = sha256hex(identity)).
+  #
+  # NOTE: only effective on a FRESH bootstrap
+  rootIdentities:
+    enabled: false
+    fileName: root-identities.yaml
+    # reference an existing Secret instead of generating one
+    existingSecret: ""
+    identities: []
+    #  - export: tenancy.kcp.io
+    #    identity: "tenancy-kcp-io-identity-CHANGEME"
+    #  - export: topology.kcp.io
+    #    identity: "topology-kcp-io-identity-CHANGEME"
+
 kcpFrontProxy:
   replicas: 1
   strategy:

--- a/charts/shard/templates/server-deployment.yaml
+++ b/charts/shard/templates/server-deployment.yaml
@@ -203,6 +203,9 @@ spec:
             {{- with .Values.kcp.batteries }}
             - --batteries-included={{ join "," . }}
             {{- end }}
+            {{- if and .Values.development.rootIdentities.enabled (or (not .Values.sharding.enabled) .Values.sharding.isRoot) }}
+            - --root-identities-file=/etc/kcp/identities/{{ .Values.development.rootIdentities.fileName }}
+            {{- end }}
             {{- range .Values.kcp.extraFlags }}
             - {{ . }}
             {{- end }}
@@ -305,6 +308,10 @@ spec:
             - name: kcp-cache-kubeconfig
               mountPath: /etc/kcp/cache/kubeconfig
             {{- end }}
+            {{- if and .Values.development.rootIdentities.enabled (or (not .Values.sharding.enabled) .Values.sharding.isRoot) }}
+            - name: kcp-root-identities
+              mountPath: /etc/kcp/identities
+            {{- end }}
 {{- with .Values.kcp.extraVolumeMounts }}
 {{ . | toYaml | indent 12 }}
 {{- end }}
@@ -389,6 +396,11 @@ spec:
           secret:
             secretName: {{ include "cache.fullname" .}}-kubeconfig
         {{- end }}
+        {{- if and .Values.development.rootIdentities.enabled (or (not .Values.sharding.enabled) .Values.sharding.isRoot) }}
+        - name: kcp-root-identities
+          secret:
+            secretName: {{ .Values.development.rootIdentities.existingSecret | default (printf "%s-root-identities" (include "kcp.fullname" .)) }}
+        {{- end }}
 {{- with .Values.kcp.extraVolumes }}
 {{ . | toYaml | indent 8 }}
 {{- end }}
@@ -411,4 +423,19 @@ stringData:
   {{ .Values.kcp.tokenAuth.fileName }}: |
     {{- .Values.kcp.tokenAuth.config | nindent 4 }}
 {{- end}}
+
+{{- if and .Values.development.rootIdentities.enabled (not .Values.development.rootIdentities.existingSecret) (or (not .Values.sharding.enabled) .Values.sharding.isRoot) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kcp.fullname" . }}-root-identities
+stringData:
+  {{ .Values.development.rootIdentities.fileName }}: |
+    identities:
+    {{- range .Values.development.rootIdentities.identities }}
+      - export: {{ .export }}
+        identity: {{ .identity | quote }}
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/shard/values.yaml
+++ b/charts/shard/values.yaml
@@ -109,6 +109,24 @@ kcp:
   # - name: foo
   #   mountPath: "/etc/foo"
   #   readOnly: true
+
+development:
+  # rootIdentities pins APIExport identity hashes in the root workspace so they are
+  # deterministic across installs/shards (identityHash = sha256hex(identity)).
+  # Only applied on the root shard (sharding.isRoot).
+  #
+  # NOTE: only effective on a FRESH bootstrap;
+  rootIdentities:
+    enabled: false
+    fileName: root-identities.yaml
+    # reference an existing Secret instead of generating one
+    existingSecret: ""
+    identities: []
+    #  - export: tenancy.kcp.io
+    #    identity: "tenancy-kcp-io-identity-CHANGEME"
+    #  - export: topology.kcp.io
+    #    identity: "topology-kcp-io-identity-CHANGEME"
+
 kcpFrontProxy:
   service:
     annotations: {}


### PR DESCRIPTION
If you want gain permissions to KCP resources of group topology or tenancy by binding another resources. The custom APIBinding and APIExport need to define the identity hash of the APIExport topology and tenancy, in `spec.permissionClaims.identityHash`. 
The secret that defines that Identity hash is created during KCP bootstrap and is immutable afterwards. KCP binary offers a flag to define those Identities to make them predictable before deployment.

This helps where KCP environments are created on demand, and relying resources would need adaption.

Helpful references:
`# kubectl explain APIBinding.spec.permissionClaims.identityHash`
`# kubectl explain APIExports.spec.permissionClaims.identityHash`
`# kubectl explain APIExports.spec.identity`
https://github.com/kcp-dev/kcp/blob/0c22b9b8391113fe796de2513b142812d7bcaa2c/pkg/server/options/options.go#L181