### PR TITLE
feat: add additional labels, annotations, and initContainers

### DIFF
--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -2,11 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: '{{ template "name" . }}'
-  {{- with .Values.additionalLabels }}
+  {{- with .Values.extraLabels }}
   labels:
     {{ toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.additionalAnnotations }}
+  {{- with .Values.extraAnnotations }}
   annotations:
     {{ toYaml . | nindent 4 }}
   {{- end }}
@@ -22,12 +22,12 @@ spec:
         app.kubernetes.io/name: kcp-api-syncagent
         app.kubernetes.io/instance: '{{ template "agentname" . }}'
         app.kubernetes.io/version: '{{ .Values.image.tag | default .Chart.AppVersion }}'
-      {{- with .Values.additionalLabels }}
+      {{- with .Values.extraLabels }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
       annotations:
         checksum/values: {{ print .Values | sha256sum }}
-      {{- with .Values.additionalAnnotations }}
+      {{- with .Values.extraAnnotations }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -4,11 +4,11 @@ metadata:
   name: '{{ template "name" . }}'
   {{- with .Values.extraLabels }}
   labels:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.extraAnnotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicas | default 1 }}
@@ -23,12 +23,12 @@ spec:
         app.kubernetes.io/instance: '{{ template "agentname" . }}'
         app.kubernetes.io/version: '{{ .Values.image.tag | default .Chart.AppVersion }}'
       {{- with .Values.extraLabels }}
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       annotations:
         checksum/values: {{ print .Values | sha256sum }}
       {{- with .Values.extraAnnotations }}
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       {{- if .Values.global.imagePullSecrets }}
@@ -41,21 +41,19 @@ spec:
       {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: agent
           args:
             - --namespace=$(POD_NAMESPACE)
             - --enable-leader-election={{ .Values.enableLeaderElection }}
-            {{- with .Values.apiExportEndpointSliceName }}
-            - --apiexportendpointslice-ref={{ . }}
+            {{- if .Values.apiExportEndpointSliceName }}
+            - --apiexportendpointslice-ref={{ .Values.apiExportEndpointSliceName }}
+            {{- else if .Values.apiExportName }}
+            - --apiexport-ref={{ .Values.apiExportName }}
             {{- else }}
-              {{ with .Values.apiExportName }}
-            - --apiexport-ref={{ . }}
-              {{- else }}
             {{- required "Either an APIExportEndpointSliceRef or APIExportRef must be configured." "" }}
-              {{- end }}
             {{- end }}
             - --agent-name=$(AGENT_NAME)
             - --kcp-kubeconfig=/etc/api-syncagent/kcp/kubeconfig

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -48,7 +48,15 @@ spec:
           args:
             - --namespace=$(POD_NAMESPACE)
             - --enable-leader-election={{ .Values.enableLeaderElection }}
-            - --apiexportendpointslice-ref={{ required "APIExportEndpointSlice name must be configured" .Values.apiExportEndpointSliceName }}
+            {{- with .Values.apiExportEndpointSliceName }}
+            - --apiexportendpointslice-ref={{ . }}
+            {{- else }}
+              {{ with .Values.apiExportName }}
+            - --apiexport-ref={{ . }}
+              {{- else }}
+            {{- required "Either an APIExportEndpointSliceRef or APIExportRef must be configured." "" }}
+              {{- end }}
+            {{- end }}
             - --agent-name=$(AGENT_NAME)
             - --kcp-kubeconfig=/etc/api-syncagent/kcp/kubeconfig
             {{- with .Values.kubeconfig }}

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -25,9 +25,8 @@ spec:
       {{- with .Values.extraLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      annotations:
-        checksum/values: {{ print .Values | sha256sum }}
       {{- with .Values.extraAnnotations }}
+      annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -2,6 +2,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: '{{ template "name" . }}'
+  {{- with .Values.additionalLabels }}
+  labels:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicas | default 1 }}
   selector:
@@ -14,6 +22,14 @@ spec:
         app.kubernetes.io/name: kcp-api-syncagent
         app.kubernetes.io/instance: '{{ template "agentname" . }}'
         app.kubernetes.io/version: '{{ .Values.image.tag | default .Chart.AppVersion }}'
+      {{- with .Values.additionalLabels }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+        checksum/values: {{ print .Values | sha256sum }}
+      {{- with .Values.additionalAnnotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
@@ -22,6 +38,10 @@ spec:
       {{- if .Values.hostAliases.enabled }}
       hostAliases:
         {{- toYaml .Values.hostAliases.values | nindent 8 }}
+      {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{ toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: agent

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -130,7 +130,13 @@ securityContext:
       drop:
         - ALL
 
+# Additional labels to add to the api-syncagent Deployment and Pods. Use this to
+# attach custom metadata for identification, selection, policy enforcement, or
+# integration with external tooling.
 extraLabels: {}
   # key: value
+
+# Additional annotations to add to the api-syncagent Deployment and Pods to be
+# used for metadata, integration with observability, policy, admission
+# controllers, or other cluster automation tools.
 extraAnnotations: {}
-  # key: value

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -99,6 +99,7 @@ extraVolumeMounts: []
 #  - name: extra-secret
 #    mountPath: /etc/test
 
+<<<<<<< HEAD
 hostAliases:
   enabled: false
   values:
@@ -129,3 +130,12 @@ securityContext:
     capabilities:
       drop:
         - ALL
+=======
+serviceAccount:
+  create: true
+  # name: custom-serviceaccount-name
+  annotations:
+    # azure.workload.identity/client-id: <clientId>
+    # azure.workload.identity/tenant-id: <tenantId>
+  labels: {}
+>>>>>>> b564796 (feat: allow custom service account name)

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -99,7 +99,6 @@ extraVolumeMounts: []
 #  - name: extra-secret
 #    mountPath: /etc/test
 
-<<<<<<< HEAD
 hostAliases:
   enabled: false
   values:
@@ -130,12 +129,8 @@ securityContext:
     capabilities:
       drop:
         - ALL
-=======
-serviceAccount:
-  create: true
-  # name: custom-serviceaccount-name
-  annotations:
-    # azure.workload.identity/client-id: <clientId>
-    # azure.workload.identity/tenant-id: <tenantId>
-  labels: {}
->>>>>>> b564796 (feat: allow custom service account name)
+
+additionalLabels: {}
+  # key: value
+additionalAnnotations: {}
+  # key: value

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -130,7 +130,7 @@ securityContext:
       drop:
         - ALL
 
-additionalLabels: {}
+extraLabels: {}
   # key: value
-additionalAnnotations: {}
+extraAnnotations: {}
   # key: value


### PR DESCRIPTION
This MR extends the api-syncagent chart with common features for deployment.

## Changes

### Additional labels & annotations (additionalLabels / additionalAnnotations)

Both are now propagated to the Deployment metadata and the pod template
Useful for workload identity, cost allocation, and observability tooling integrations

### checksum annotation is automatically added to the pod template
Triggers a rolling restart whenever chart values change, preventing stale pod configurations

### Added initContainers support to the pod spec via values

Enables pre-start setup (e.g. Azure Workload Identity sidecar init)

### Flexible APIExport reference

Previously apiExportEndpointSliceName was required; the chart now accepts either apiExportEndpointSliceName or apiExportName
If neither is set, a descriptive validation error is raised at render time