### PR TITLE
Bump kcp to 0.32.1 and kcp-operator to v0.8.1

### DIFF
--- a/charts/kcp-operator/Chart.yaml
+++ b/charts/kcp-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kcp-operator
 description: A Helm chart for kcp-operator, a Kubernetes operator to deploy and manage kcp instances.
 # version information
-version: 0.7.4
-appVersion: "v0.8.0"
+version: 0.7.5
+appVersion: "v0.8.1"
 # optional metadata
 type: application
 home: https://kcp.io

--- a/charts/kcp/Chart.yaml
+++ b/charts/kcp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kcp
 description: A multi-tenant Kubernetes control plane for workloads on many clusters
 # version information
-version: 0.16.3
-appVersion: "0.32.0"
+version: 0.16.4
+appVersion: "0.32.1"
 # optional metadata
 type: application
 home: https://www.kcp.io/


### PR DESCRIPTION
Bumps the kcp chart (appVersion 0.32.1) and kcp-operator chart (appVersion v0.8.1).