### PR TITLE
Wire requestheader-* and mount-proxy-* flags

### DIFF
--- a/charts/certificates/templates/server-certificates.yaml
+++ b/charts/certificates/templates/server-certificates.yaml
@@ -239,4 +239,35 @@ spec:
 {{- end }}
 
 {{- end }}
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}-mounts-proxy
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  secretName: {{ include "kcp.fullname" . }}-mounts-proxy-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: kcp-mounts-proxy
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  issuerRef:
+    name: {{ include "certificates.kcp" . }}-requestheader-client-issuer
+{{- if .Values.certificates.secretTemplate.enabled }}
+  secretTemplate:
+{{- if .Values.certificates.secretTemplate.annotations }}
+    annotations:
+    {{- toYaml .Values.certificates.secretTemplate.annotations | nindent 6 }}
+{{- end }}
+{{- if .Values.certificates.secretTemplate.labels }}
+    labels:
+    {{- toYaml .Values.certificates.secretTemplate.labels | nindent 6 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kcp/templates/_helpers.tpl
+++ b/charts/kcp/templates/_helpers.tpl
@@ -58,6 +58,17 @@ v{{- .Chart.AppVersion -}}
 {{- end -}}
 {{- end -}}
 
+{{- define "kcp.mountsProxyCompatible" -}}
+{{- $version := trimPrefix "v" . -}}
+{{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" $version -}}
+{{- if semverCompare ">=0.31.6 <0.32.0 || >=0.32.3" $version -}}
+true
+{{- end -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{- define "etcd.fullname" -}}
 {{- $trimmedName := printf "%s" (include "kcp.fullname" .) | trunc 58 | trimSuffix "-" -}}
 {{- printf "%s-etcd" $trimmedName | trunc 63 | trimSuffix "-" -}}

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -97,6 +97,13 @@ spec:
             - --tls-private-key-file=/etc/kcp-front-proxy/tls/tls.key
             - --tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt
             - --client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt
+            {{- if include "kcp.mountsProxyCompatible" (include "frontproxy.version" .) }}
+            - --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client-ca/tls.crt
+            - --requestheader-allowed-names=kcp-mounts-proxy
+            - --requestheader-username-headers=X-Remote-User
+            - --requestheader-group-headers=X-Remote-Group
+            - --requestheader-extra-headers-prefix=X-Remote-Extra-
+            {{- end }}
             - --service-account-key-file=/etc/kcp/tls/service-account/tls.key
             - --mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml
             - --v={{ .Values.kcpFrontProxy.v }}
@@ -155,6 +162,10 @@ spec:
               mountPath: /etc/kcp-front-proxy/tls
             - name: kcp-front-proxy-client-ca
               mountPath: /etc/kcp-front-proxy/client-ca
+            {{- if include "kcp.mountsProxyCompatible" (include "frontproxy.version" .) }}
+            - name: kcp-requestheader-client-ca
+              mountPath: /etc/kcp/tls/requestheader-client-ca
+            {{- end }}
             - name: kcp-service-account-cert
               mountPath: /etc/kcp/tls/service-account
             - name: kcp-front-proxy-config
@@ -194,6 +205,11 @@ spec:
         - name: kcp-front-proxy-client-ca
           secret:
             secretName: {{ include "frontproxy.fullname" . }}-client-ca
+        {{- if include "kcp.mountsProxyCompatible" (include "frontproxy.version" .) }}
+        - name: kcp-requestheader-client-ca
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-requestheader-client-ca
+        {{- end }}
         - name: kcp-service-account-cert
           secret:
             secretName: {{ include "kcp.fullname" . }}-service-account-cert

--- a/charts/kcp/templates/server-certificates.yaml
+++ b/charts/kcp/templates/server-certificates.yaml
@@ -141,3 +141,25 @@ spec:
     name: {{ include "kcp.fullname" . }}-service-account-issuer
     kind: Issuer
     group: cert-manager.io
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kcp.fullname" . }}-mounts-proxy
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "server"
+spec:
+  secretName: {{ include "kcp.fullname" . }}-mounts-proxy-cert
+  duration: 8760h # 365d
+  renewBefore: 360h # 15d
+  commonName: kcp-mounts-proxy
+  privateKey:
+    {{- toYaml .Values.certificates.privateKeys | nindent 4 }}
+  usages:
+    - client auth
+  issuerRef:
+    name: {{ include "kcp.fullname" . }}-requestheader-client-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -156,6 +156,10 @@ spec:
             - --requestheader-username-headers=X-Remote-User
             - --requestheader-group-headers=X-Remote-Group
             - --requestheader-extra-headers-prefix=X-Remote-Extra-
+            {{- if include "kcp.mountsProxyCompatible" (include "kcp.version" .) }}
+            - --mount-proxy-client-cert-file=/etc/kcp/tls/mounts-proxy/tls.crt
+            - --mount-proxy-client-key-file=/etc/kcp/tls/mounts-proxy/tls.key
+            {{- end }}
             - --root-directory=
             - --shard-virtual-workspace-ca-file=/etc/kcp/tls/ca/tls.crt
             - --shard-base-url=https://{{ include "kcp.fullname" . }}:6443
@@ -260,6 +264,10 @@ spec:
               mountPath: /etc/kcp/tls/service-account-ca
             - name: kcp-requestheader-client-ca
               mountPath: /etc/kcp/tls/requestheader-client-ca
+            {{- if include "kcp.mountsProxyCompatible" (include "kcp.version" .) }}
+            - name: kcp-mounts-proxy-cert
+              mountPath: /etc/kcp/tls/mounts-proxy
+            {{- end }}
             {{- if .Values.authentication.configMapRef.name }}
             - name: kcp-authentication-config
               mountPath: /etc/kcp/authentication
@@ -328,6 +336,11 @@ spec:
         - name: kcp-requestheader-client-ca
           secret:
             secretName: {{ include "kcp.fullname" . }}-requestheader-client-ca
+        {{- if include "kcp.mountsProxyCompatible" (include "kcp.version" .) }}
+        - name: kcp-mounts-proxy-cert
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-mounts-proxy-cert
+        {{- end }}
         {{- if .Values.authentication.configMapRef.name }}
         - name: kcp-authentication-config
           configMap:

--- a/charts/proxy/templates/_helpers.tpl
+++ b/charts/proxy/templates/_helpers.tpl
@@ -85,6 +85,17 @@ v{{- .Chart.AppVersion -}}
 {{- end -}}
 {{- end -}}
 
+{{- define "kcp.mountsProxyCompatible" -}}
+{{- $version := trimPrefix "v" . -}}
+{{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" $version -}}
+{{- if semverCompare ">=0.31.6 <0.32.0 || >=0.32.3" $version -}}
+true
+{{- end -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{- define "certificates.etcd" -}}
 {{- if not (eq .Values.certificates.name "") -}}
 {{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}

--- a/charts/proxy/templates/front-proxy-deployment.yaml
+++ b/charts/proxy/templates/front-proxy-deployment.yaml
@@ -88,6 +88,13 @@ spec:
             - --tls-private-key-file=/etc/kcp-front-proxy/tls/tls.key
             - --tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt
             - --client-ca-file=/etc/kcp-front-proxy/client-ca/tls.crt
+            {{- if include "kcp.mountsProxyCompatible" (include "frontproxy.version" .) }}
+            - --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client-ca/tls.crt
+            - --requestheader-allowed-names=kcp-mounts-proxy
+            - --requestheader-username-headers=X-Remote-User
+            - --requestheader-group-headers=X-Remote-Group
+            - --requestheader-extra-headers-prefix=X-Remote-Extra-
+            {{- end }}
             - --service-account-key-file=/etc/kcp/tls/service-account/tls.key
             - --service-account-lookup=false
             - --mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml
@@ -144,6 +151,10 @@ spec:
               mountPath: /etc/kcp-front-proxy/tls
             - name: kcp-front-proxy-client-ca
               mountPath: /etc/kcp-front-proxy/client-ca
+            {{- if include "kcp.mountsProxyCompatible" (include "frontproxy.version" .) }}
+            - name: kcp-requestheader-client-ca
+              mountPath: /etc/kcp/tls/requestheader-client-ca
+            {{- end }}
             - name: kcp-service-account-cert
               mountPath: /etc/kcp/tls/service-account
             - name: kcp-front-proxy-config
@@ -187,6 +198,11 @@ spec:
         - name: kcp-front-proxy-client-ca
           secret:
             secretName: {{ include "certificates.frontproxy" . }}-client-ca
+        {{- if include "kcp.mountsProxyCompatible" (include "frontproxy.version" .) }}
+        - name: kcp-requestheader-client-ca
+          secret:
+            secretName: {{ include "certificates.kcp" . }}-requestheader-client-ca
+        {{- end }}
         - name: kcp-service-account-cert
           secret:
             secretName: {{ include "certificates.kcp" . }}-service-account-ca

--- a/charts/shard/templates/_helpers.tpl
+++ b/charts/shard/templates/_helpers.tpl
@@ -85,6 +85,17 @@ v{{- .Chart.AppVersion -}}
 {{- end -}}
 {{- end -}}
 
+{{- define "kcp.mountsProxyCompatible" -}}
+{{- $version := trimPrefix "v" . -}}
+{{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" $version -}}
+{{- if semverCompare ">=0.31.6 <0.32.0 || >=0.32.3" $version -}}
+true
+{{- end -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{- define "certificates.etcd" -}}
 {{- if not (eq .Values.certificates.name "") -}}
 {{- $trimmedName := printf "%s" .Values.certificates.name | trunc 58 | trimSuffix "-" -}}

--- a/charts/shard/templates/server-deployment.yaml
+++ b/charts/shard/templates/server-deployment.yaml
@@ -156,6 +156,10 @@ spec:
             - --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client-ca/tls.crt
             - --requestheader-username-headers=X-Remote-User
             - --requestheader-group-headers=X-Remote-Group
+            {{- if include "kcp.mountsProxyCompatible" (include "kcp.version" .) }}
+            - --mount-proxy-client-cert-file=/etc/kcp/tls/mounts-proxy/tls.crt
+            - --mount-proxy-client-key-file=/etc/kcp/tls/mounts-proxy/tls.key
+            {{- end }}
             - --root-directory=/etc/kcp/config
             - --shard-virtual-workspace-ca-file=/etc/kcp/tls/ca/tls.crt
             {{- if .Values.sharding.enabled }}
@@ -269,6 +273,10 @@ spec:
               mountPath: /etc/kcp/tls/service-account
             - name: kcp-requestheader-client-ca
               mountPath: /etc/kcp/tls/requestheader-client-ca
+            {{- if include "kcp.mountsProxyCompatible" (include "kcp.version" .) }}
+            - name: kcp-mounts-proxy-cert
+              mountPath: /etc/kcp/tls/mounts-proxy
+            {{- end }}
             {{- if .Values.authentication.configMapRef.name }}
             - name: kcp-authentication-config
               mountPath: /etc/kcp/authentication
@@ -344,6 +352,11 @@ spec:
         - name: kcp-requestheader-client-ca
           secret:
             secretName: {{ include "certificates.kcp" . }}-requestheader-client-ca
+        {{- if include "kcp.mountsProxyCompatible" (include "kcp.version" .) }}
+        - name: kcp-mounts-proxy-cert
+          secret:
+            secretName: {{ include "kcp.fullname" . }}-mounts-proxy-cert
+        {{- end }}
         {{- if .Values.authentication.configMapRef.name }}
         - name: kcp-authentication-config
           configMap:


### PR DESCRIPTION
Wire `requestheader-*` and `mount-proxy-*` flags introduced in https://github.com/kcp-dev/kcp/pull/4238

/hold
requires a new kcp release

/assign @xrstf 