### PR TITLE
fix(api-syncagent): bump CRDs to shipped 0.7.0 app version

### DIFF
--- a/charts/api-syncagent/Chart.yaml
+++ b/charts/api-syncagent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: api-syncagent
 description: A Kubernetes agent to synchronize APIs and their objects between Kubernetes clusters and kcp.
 # version information
-version: 0.6.1
+version: 0.6.2
 appVersion: "v0.7.0"
 # optional metadata
 type: application

--- a/charts/api-syncagent/templates/crd-publishedresource.yaml
+++ b/charts/api-syncagent/templates/crd-publishedresource.yaml
@@ -380,6 +380,13 @@ spec:
                       (in the following rule, group is optional becaue core/v1 is represented by group="")
                       group is included here because when an identityHash is used, core/v1 cannot possible be targetted
                     properties:
+                      cleanup:
+                        description: |-
+                          Cleanup can be set to true to make the syncagent delete any copy of this related resource on
+                          the destination side (i.e. the original related object will not be touched, regardless of this
+                          option). Leaving this disabled, the syncagent will only create copies of the related objects,
+                          but never delete them itself.
+                        type: boolean
                       group:
                         description: |-
                           Group is the API group of the related resource. This should be left blank for resources
@@ -777,6 +784,70 @@ spec:
                           Version is the API version of the related resource. This can be left blank to automatically
                           use the preferred version.
                         type: string
+                      watch:
+                        description: |-
+                          Watch configures how the agent identifies the owning primary object when a related
+                          resource with origin: kcp changes. When set, the agent sets up a watch on the related
+                          resource type and uses the configured rule to enqueue the correct primary object.
+                          Without this field, changes to origin:kcp related resources do not trigger reconciliation.
+                        properties:
+                          byOwner:
+                            description: |-
+                              ByOwner configures the watch handler to inspect the OwnerReferences of the changed
+                              object. When an OwnerReference with the given Kind is found, the referenced owner
+                              is enqueued as the primary object.
+                            type: object
+                          bySelector:
+                            description: |-
+                              BySelector configures the watch handler to list primary objects matching the given label
+                              selector. When a related object changes, all primary objects matching this selector
+                              are enqueued for reconciliation.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-validations:
+                          - message: exactly one of byOwner or bySelector must be set
+                            rule: has(self.byOwner) != has(self.bySelector)
                     required:
                       - identifier
                       - object

--- a/hack/bump-versions.sh
+++ b/hack/bump-versions.sh
@@ -89,7 +89,8 @@ for chart in "${!CHART_REPOS[@]}"; do
   changed+=("$chart")
 done
 
-# Regenerate kcp-operator CRDs if it was bumped
+# Regenerate CRDs if charts with CRDs were bumped
+
 if printf '%s\n' "${changed[@]}" | grep -qx "kcp-operator"; then
   if [[ "$DRY_RUN" == true ]]; then
     echo ""
@@ -98,6 +99,17 @@ if printf '%s\n' "${changed[@]}" | grep -qx "kcp-operator"; then
     echo ""
     echo "Regenerating kcp-operator CRDs..."
     hack/update-kcp-operator-crds.sh
+  fi
+fi
+
+if printf '%s\n' "${changed[@]}" | grep -qx "api-syncagent"; then
+  if [[ "$DRY_RUN" == true ]]; then
+    echo ""
+    echo "Would regenerate api-syncagent CRDs"
+  else
+    echo ""
+    echo "Regenerating api-syncagent CRDs..."
+    hack/update-apisyncagent-crds.sh
   fi
 fi
 

--- a/hack/update-apisyncagent-crds.sh
+++ b/hack/update-apisyncagent-crds.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cd $(dirname $0)/..
+
+cd charts/api-syncagent/
+version="$(yq '.appVersion' Chart.yaml)"
+crdFile=templates/crd-publishedresource.yaml
+
+set -x
+
+echo "{{- if .Values.crds.enabled }}{{\`" > "$crdFile"
+# tail is used to cut header from CRD file
+curl https://raw.githubusercontent.com/kcp-dev/api-syncagent/refs/tags/${version}/deploy/crd/kcp.io/syncagent.kcp.io_publishedresources.yaml -o - | tail -n +3 | yq >> "$crdFile"
+echo "\`}}" >> "$crdFile"
+echo "{{- end }}" >> "$crdFile"


### PR DESCRIPTION
Fixes #233.

Looks like the version bump script by @mjudeikis was unaware of api-syncagent, so the last few version bumps done with it have skipped updating the `PublishedResource` CRD. I guess for 0.6.0 we had no changes, but for 0.7.0 (#230), the update meant that the new CRD fields were not shipped.

I've also updated the scripts so this doesn't happen again.