### PR TITLE
feat(api-syncagent): make resource names unique

### DIFF
--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: '{{ template "name" . }}'
+  name: '{{ include "api-syncagent.fullname" . }}'
   {{- with .Values.extraLabels }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/charts/api-syncagent/templates/rbac.yaml
+++ b/charts/api-syncagent/templates/rbac.yaml
@@ -51,7 +51,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: '{{ template "name" . }}:{{ .Release.Namespace }}:events'
+  name: '{{ template "api-syncagent.fullname" . }}:{{ .Release.Namespace }}:events'
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -134,7 +134,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: '{{ template "name" . }}:{{ .Release.Namespace }}'
+  name: '{{ template "api-syncagent.fullname" . }}:{{ .Release.Namespace }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Currently the name of the Deployment and (Cluster)RoleBinding resources is generated using the `name` template which uses the `.Release.Name` which however does not allow embedding the chart multiple times into another chart, with a different alias each.

This PR makes the names of Deployment and (Cluster)RoleBindings unique also in case the api-syncagent Helm chart is included within another chart multiple times, each with a different alias.
It does that by using the existing `api-syncagent.fullname` template helper function that takes the chart alias into account.

cc @SimonTheLeg 