### PR TITLE
fix(api-syncagent): make RBAC resource names instance specific

### DIFF
--- a/charts/api-syncagent/templates/rbac.yaml
+++ b/charts/api-syncagent/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: '{{ template "name" . }}:leaderelection'
+  name: '{{ include "api-syncagent.fullname" . }}:leaderelection'
 rules:
   - apiGroups:
       - coordination.k8s.io
@@ -56,7 +56,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: '{{ template "name" . }}:{{ .Release.Namespace }}:events'
+  name: '{{ include "api-syncagent.fullname" . }}:{{ .Release.Namespace }}:events'
 subjects:
   - apiGroup: ""
     kind: ServiceAccount
@@ -67,7 +67,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: '{{ template "name" . }}:{{ .Release.Namespace }}:events'
+  name: '{{ include "api-syncagent.fullname" . }}:{{ .Release.Namespace }}:events'
   namespace: default
 rules:
   - apiGroups:
@@ -83,7 +83,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ template "name" . }}:{{ .Release.Namespace }}'
+  name: '{{ include "api-syncagent.fullname" . }}:{{ .Release.Namespace }}'
 rules:
   - apiGroups:
       - ""
@@ -138,7 +138,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{ template "name" . }}:{{ .Release.Namespace }}'
+  name: '{{ include "api-syncagent.fullname" . }}:{{ .Release.Namespace }}'
 subjects:
   - apiGroup: ""
     kind: ServiceAccount


### PR DESCRIPTION
This PR uses api syncagent fullname consistently for RBAC resources and some other references so that a parent chart can have multiple configured syncagents.
