### PR TITLE
feat(api-syncagent): support namespace overrides

### DIFF
--- a/charts/api-syncagent/templates/_helpers.tpl
+++ b/charts/api-syncagent/templates/_helpers.tpl
@@ -1,6 +1,10 @@
 {{- define "name" -}}{{ .Release.Name }}{{- end }}
 {{- define "agentname" -}}{{ .Values.agentName | default .Release.Name }}{{- end }}
 
+{{- define "api-syncagent.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | quote -}}
+{{- end }}
+
 {{- define "imagePullSecrets" -}}
 {{- range .Values.global.imagePullSecrets }}
 {{- if eq (typeOf .) "map[string]interface {}" }}

--- a/charts/api-syncagent/templates/deployment.yaml
+++ b/charts/api-syncagent/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: '{{ include "api-syncagent.fullname" . }}'
+  namespace: {{ include "api-syncagent.namespace" . }}
   {{- with .Values.extraLabels }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/charts/api-syncagent/templates/rbac.yaml
+++ b/charts/api-syncagent/templates/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: '{{ include "api-syncagent.fullname" . }}:leaderelection'
+  namespace: {{ include "api-syncagent.namespace" . }}
 rules:
   - apiGroups:
       - coordination.k8s.io
@@ -28,6 +29,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "api-syncagent.fullname" . }}:{{ include "api-syncagent.serviceAccountName" . }}:leaderelection
+  namespace: {{ include "api-syncagent.namespace" . }}
   labels:
     {{- include "api-syncagent.labels" . | nindent 4 }}
   annotations:
@@ -40,7 +42,7 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ include "api-syncagent.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "api-syncagent.namespace" . }}
 
 ---
 # A dedicated role and binding just to allow the agent to publish events on PublishedResources,
@@ -61,7 +63,7 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ include "api-syncagent.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "api-syncagent.namespace" . }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -143,4 +145,4 @@ subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ include "api-syncagent.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "api-syncagent.namespace" . }}

--- a/charts/api-syncagent/templates/serviceaccount.yaml
+++ b/charts/api-syncagent/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "api-syncagent.serviceAccountName" . }}
+  namespace: {{ include "api-syncagent.namespace" . }}
   labels:
     {{- include "api-syncagent.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/api-syncagent/values.yaml
+++ b/charts/api-syncagent/values.yaml
@@ -10,6 +10,9 @@ global:
 nameOverride: ""
 fullnameOverride: ""
 
+# Override the namespace for namespaced resources. The namespace must already exist.
+namespaceOverride: ""
+
 # Required: You need to configure a reference to an APIExportEndpointSlice so the
 # agent knows which API to serve and where to connect to.
 apiExportEndpointSliceName: ""


### PR DESCRIPTION
Add `namespaceOverride` for deploying namespaced resources outside the Helm release namespace. We will fall back to `.Release.Namespace` when unset.