### PR TITLE
feat(kcp): configurable pod and container securityContext

### DIFF
--- a/charts/kcp/templates/etcd-statefulset.yaml
+++ b/charts/kcp/templates/etcd-statefulset.yaml
@@ -68,9 +68,17 @@ spec:
       {{- with .Values.etcd.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with (.Values.etcd.podSecurityContext | default .Values.etcd.securityContext) }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: etcd
           image: {{ .Values.etcd.image }}:{{ .Values.etcd.tag }}
+          {{- with .Values.etcd.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
           - etcd
           - --name=$(HOSTNAME)

--- a/charts/kcp/templates/etcd-statefulset.yaml
+++ b/charts/kcp/templates/etcd-statefulset.yaml
@@ -68,7 +68,7 @@ spec:
       {{- with .Values.etcd.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- with (.Values.etcd.podSecurityContext | default .Values.etcd.securityContext) }}
+      {{- with .Values.etcd.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -56,7 +56,7 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app.kubernetes.io/component: "front-proxy"
     spec:
-      {{- with .Values.kcpFrontProxy.securityContext }}
+      {{- with (.Values.kcpFrontProxy.podSecurityContext | default .Values.kcpFrontProxy.securityContext) }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -87,6 +87,10 @@ spec:
         - name: kcp-front-proxy
           image: "{{ .Values.kcpFrontProxy.image }}:{{- include "frontproxy.version" . }}"
           imagePullPolicy: {{ .Values.kcpFrontProxy.pullPolicy }}
+          {{- with .Values.kcpFrontProxy.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ["/kcp-front-proxy"]
           args:
             - --secure-port=8443

--- a/charts/kcp/templates/front-proxy-deployment.yaml
+++ b/charts/kcp/templates/front-proxy-deployment.yaml
@@ -56,7 +56,7 @@ spec:
         {{- include "common.labels" . | nindent 8 }}
         app.kubernetes.io/component: "front-proxy"
     spec:
-      {{- with (.Values.kcpFrontProxy.podSecurityContext | default .Values.kcpFrontProxy.securityContext) }}
+      {{- with (merge .Values.kcpFrontProxy.securityContext .Values.kcpFrontProxy.podSecurityContext) }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -90,7 +90,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.kcp.securityContext }}
+      {{- with (.Values.kcp.podSecurityContext | default .Values.kcp.securityContext) }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -121,8 +121,10 @@ spec:
         - name: kcp
           image: {{ .Values.kcp.image }}:{{- include "kcp.version" . }}
           imagePullPolicy: {{ .Values.kcp.pullPolicy }}
+          {{- with .Values.kcp.containerSecurityContext }}
           securityContext:
-            readOnlyRootFilesystem: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 6443
             {{- if .Values.kcp.profiling.enabled }}

--- a/charts/kcp/templates/server-deployment.yaml
+++ b/charts/kcp/templates/server-deployment.yaml
@@ -90,7 +90,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (.Values.kcp.podSecurityContext | default .Values.kcp.securityContext) }}
+      {{- with (merge .Values.kcp.securityContext .Values.kcp.podSecurityContext) }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -55,8 +55,6 @@ etcd:
   # When configured, this will set the priority class for etcd pods.
   priorityClassName: ""
 
-  # DEPRECATED: use podSecurityContext instead.
-  securityContext: {}
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 65534

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -55,6 +55,23 @@ etcd:
   # When configured, this will set the priority class for etcd pods.
   priorityClassName: ""
 
+  # DEPRECATED: use podSecurityContext instead.
+  securityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -141,9 +158,20 @@ kcp:
   homeWorkspaces:
     enabled: false
 
-  securityContext:
-    # This matches the group id as set in the kcp Dockerfile.
+  # DEPRECATED: use podSecurityContext instead.
+  securityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532  # This matches the user id as set in the kcp Dockerfile.
+    runAsGroup: 65532
     fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
     seccompProfile:
       type: RuntimeDefault
 
@@ -294,7 +322,19 @@ kcpFrontProxy:
       - ip: ""
         hostnames: []
 
-  securityContext:
+  # DEPRECATED: use podSecurityContext instead.
+  securityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
     seccompProfile:
       type: RuntimeDefault
 

--- a/charts/kcp/values.yaml
+++ b/charts/kcp/values.yaml
@@ -166,6 +166,7 @@ kcp:
     seccompProfile:
       type: RuntimeDefault
   containerSecurityContext:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     capabilities:
       drop:


### PR DESCRIPTION
Hello,

I want to propose this MR to add _podSecurityContext_ and _containerSecurityContext_ values for all three components (kcp server, kcp-front-proxy, etcd) with hardened default values. Making the _securityContext_ values deprecated.

The motivation is:
- To improve deployment security (for example _etcd_ had no securityContext whatsoever)
- Help Kubernetes admin to deploy KCP on restricted Kubernetes. For example SUSE Rancher enforce Pod Security Standard to _restricted_ by default.
- Allow customisation of the securityContext of pod spec or container spec.

These security context have been tested against the "restricted" Pod Security Standards: https://kubernetes.io/docs/concepts/security/pod-security-standards/

What do you think of the changes? Could they be merge into the KCP Helm chart? I can also split the merge request into two parts. If we’d prefer to merge only the customisation part of the _securityContext_, and add the restricted level by dfault later.